### PR TITLE
Remove unnecessary async from tool functions

### DIFF
--- a/src/thenvoi_mcp/server.py
+++ b/src/thenvoi_mcp/server.py
@@ -11,7 +11,7 @@ from thenvoi_mcp.tools import participants  # noqa: F401
 
 
 @mcp.tool()
-async def health_check(ctx: Context) -> str:
+def health_check(ctx: Context) -> str:
     """Test MCP server and API connectivity."""
     try:
         app_ctx = get_app_context(ctx)

--- a/src/thenvoi_mcp/tests/test_agents.py
+++ b/src/thenvoi_mcp/tests/test_agents.py
@@ -1,12 +1,10 @@
 import time
-import pytest
 
 
 class TestAgentIntegration:
     """Test agent management tools against real API."""
 
-    @pytest.mark.asyncio
-    async def test_agent_lifecycle(self, setup_test_client):
+    def test_agent_lifecycle(self, setup_test_client):
         """Test creating, reading, updating, and deleting an agent."""
         from thenvoi_mcp.tools.agents import (
             get_agent,
@@ -33,22 +31,22 @@ class TestAgentIntegration:
 
         try:
             # 2. Get agent
-            get_result = await get_agent(ctx, agent_id=agent_id)
+            get_result = get_agent(ctx, agent_id=agent_id)
             assert f"Test Agent Integration {timestamp}" in get_result
             assert agent_id in get_result
 
             # 3. Update agent (use unique name for update too)
-            update_result = await update_agent(
+            update_result = update_agent(
                 ctx, agent_id=agent_id, name=f"Updated Test Agent {timestamp}"
             )
             assert "Agent updated successfully" in update_result
 
             # 4. Verify update
-            get_updated = await get_agent(ctx, agent_id=agent_id)
+            get_updated = get_agent(ctx, agent_id=agent_id)
             assert f"Updated Test Agent {timestamp}" in get_updated
 
             # 5. List agents (should include our test agent)
-            list_result = await list_agents(ctx)
+            list_result = list_agents(ctx)
             assert agent_id in list_result
 
         finally:
@@ -58,8 +56,7 @@ class TestAgentIntegration:
             except Exception as e:
                 print(f"Warning: Failed to cleanup agent {agent_id}: {e}")
 
-    @pytest.mark.asyncio
-    async def test_agent_with_structured_output(self, setup_test_client):
+    def test_agent_with_structured_output(self, setup_test_client):
         """Test creating agent with structured output schema."""
         from thenvoi_mcp.tools.agents import get_agent
 
@@ -91,7 +88,7 @@ class TestAgentIntegration:
 
         try:
             # Verify agent was created
-            get_result = await get_agent(ctx, agent_id=agent_id)
+            get_result = get_agent(ctx, agent_id=agent_id)
             assert agent_id in get_result
         finally:
             # Cleanup: Delete agent

--- a/src/thenvoi_mcp/tests/test_chats.py
+++ b/src/thenvoi_mcp/tests/test_chats.py
@@ -1,12 +1,10 @@
 import time
-import pytest
 
 
 class TestChatIntegration:
     """Test chat management tools against real API."""
 
-    @pytest.mark.asyncio
-    async def test_chat_lifecycle(self, setup_test_client):
+    def test_chat_lifecycle(self, setup_test_client):
         """Test creating, reading, updating, and deleting a chat."""
         from thenvoi_mcp.tools.chats import (
             create_chat,
@@ -35,7 +33,7 @@ class TestChatIntegration:
 
         try:
             # 1. Create chat
-            create_result = await create_chat(
+            create_result = create_chat(
                 ctx,
                 title=f"Test Chat Integration {timestamp}",
                 chat_type="direct",
@@ -48,23 +46,23 @@ class TestChatIntegration:
 
             try:
                 # 2. Get chat
-                get_result = await get_chat(ctx, chat_id=chat_id)
+                get_result = get_chat(ctx, chat_id=chat_id)
                 assert f"Test Chat Integration {timestamp}" in get_result
                 assert chat_id in get_result
 
                 # 3. Update chat
-                update_result = await update_chat(
+                update_result = update_chat(
                     ctx, chat_id=chat_id, title=f"Updated Test Chat {timestamp}"
                 )
                 assert "Chat room updated successfully" in update_result
 
                 # 4. List chats (should include our test chat)
-                list_result = await list_chats(ctx)
+                list_result = list_chats(ctx)
                 assert chat_id in list_result
 
             finally:
                 # Cleanup: Delete chat
-                await delete_chat(ctx, chat_id=chat_id)
+                delete_chat(ctx, chat_id=chat_id)
         finally:
             # Cleanup: Delete agent
             try:

--- a/src/thenvoi_mcp/tests/test_messages.py
+++ b/src/thenvoi_mcp/tests/test_messages.py
@@ -1,12 +1,10 @@
 import time
-import pytest
 
 
 class TestMessageIntegration:
     """Test message management tools against real API."""
 
-    @pytest.mark.asyncio
-    async def test_message_lifecycle(self, setup_test_client):
+    def test_message_lifecycle(self, setup_test_client):
         """Test creating, listing, and deleting messages."""
         from thenvoi_mcp.tools.chats import create_chat, delete_chat
         from thenvoi_mcp.tools.messages import (
@@ -32,7 +30,7 @@ class TestMessageIntegration:
         assert agent_id is not None
 
         try:
-            create_chat_result = await create_chat(
+            create_chat_result = create_chat(
                 ctx,
                 title=f"Test Chat for Messages {timestamp}",
                 chat_type="direct",
@@ -45,7 +43,7 @@ class TestMessageIntegration:
 
             try:
                 # 1. Create message (note: create_chat_message now gets sender from auth)
-                create_msg_result = await create_chat_message(
+                create_msg_result = create_chat_message(
                     ctx,
                     chat_id=chat_id,
                     content="Test message from integration test",
@@ -55,13 +53,13 @@ class TestMessageIntegration:
                 message_id = create_msg_result.split(": ")[1].strip()
 
                 # 2. List messages (should include our test message)
-                list_result = await list_chat_messages(ctx, chat_id=chat_id)
+                list_result = list_chat_messages(ctx, chat_id=chat_id)
                 assert message_id in list_result
                 assert "Test message from integration test" in list_result
 
             finally:
                 # Cleanup: Delete chat
-                await delete_chat(ctx, chat_id=chat_id)
+                delete_chat(ctx, chat_id=chat_id)
         finally:
             # Cleanup: Delete agent
             try:

--- a/src/thenvoi_mcp/tests/test_participants.py
+++ b/src/thenvoi_mcp/tests/test_participants.py
@@ -1,12 +1,10 @@
 import time
-import pytest
 
 
 class TestParticipantIntegration:
     """Test participant management tools against real API."""
 
-    @pytest.mark.asyncio
-    async def test_participant_lifecycle(self, setup_test_client):
+    def test_participant_lifecycle(self, setup_test_client):
         """Test adding, listing, and removing participants."""
         from thenvoi_mcp.tools.chats import create_chat, delete_chat
         from thenvoi_mcp.tools.participants import (
@@ -34,7 +32,7 @@ class TestParticipantIntegration:
         assert owner_agent_id is not None
 
         try:
-            create_chat_result = await create_chat(
+            create_chat_result = create_chat(
                 ctx,
                 title=f"Test Chat for Participants {timestamp}",
                 chat_type="group",
@@ -58,23 +56,23 @@ class TestParticipantIntegration:
 
             try:
                 # 1. List available participants
-                available_result = await list_available_participants(
+                available_result = list_available_participants(
                     ctx, chat_id=chat_id, participant_type="Agent"
                 )
                 assert "participants" in available_result
 
                 # 2. Add participant
-                add_result = await add_chat_participant(
+                add_result = add_chat_participant(
                     ctx, chat_id=chat_id, participant_id=agent_id, role="member"
                 )
                 assert "Participant added successfully" in add_result
 
                 # 3. List participants (should include our agent)
-                list_result = await list_chat_participants(ctx, chat_id=chat_id)
+                list_result = list_chat_participants(ctx, chat_id=chat_id)
                 assert agent_id in list_result
 
                 # 4. Remove participant
-                remove_result = await remove_chat_participant(
+                remove_result = remove_chat_participant(
                     ctx, chat_id=chat_id, participant_id=agent_id
                 )
                 assert "Participant removed successfully" in remove_result
@@ -85,7 +83,7 @@ class TestParticipantIntegration:
                     client.agents.delete_agent(id=agent_id)
                 except Exception as e:
                     print(f"Warning: Failed to cleanup agent {agent_id}: {e}")
-                await delete_chat(ctx, chat_id=chat_id)
+                delete_chat(ctx, chat_id=chat_id)
         finally:
             # Cleanup: Delete owner agent
             try:

--- a/src/thenvoi_mcp/tools/agents.py
+++ b/src/thenvoi_mcp/tools/agents.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 @mcp.tool()
-async def list_agents(ctx: AppContextType) -> str:
+def list_agents(ctx: AppContextType) -> str:
     """List all accessible agents.
 
     Returns a list of agents that the authenticated user has access to.
@@ -44,7 +44,7 @@ async def list_agents(ctx: AppContextType) -> str:
 
 
 @mcp.tool()
-async def get_agent(ctx: AppContextType, agent_id: str) -> str:
+def get_agent(ctx: AppContextType, agent_id: str) -> str:
     """Get a specific agent by ID.
 
     Retrieves detailed information about a single agent.
@@ -79,7 +79,7 @@ async def get_agent(ctx: AppContextType, agent_id: str) -> str:
 
 
 @mcp.tool()
-async def update_agent(
+def update_agent(
     ctx: AppContextType,
     agent_id: str,
     name: Optional[str] = None,
@@ -151,7 +151,7 @@ async def update_agent(
 
 
 @mcp.tool()
-async def list_agent_chats(
+def list_agent_chats(
     ctx: AppContextType,
     agent_id: str,
     page: Optional[int] = None,

--- a/src/thenvoi_mcp/tools/chats.py
+++ b/src/thenvoi_mcp/tools/chats.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 @mcp.tool()
-async def list_chats(
+def list_chats(
     ctx: AppContextType,
     page: Optional[int] = None,
     per_page: Optional[int] = None,
@@ -66,7 +66,7 @@ async def list_chats(
 
 
 @mcp.tool()
-async def get_chat(ctx: AppContextType, chat_id: str) -> str:
+def get_chat(ctx: AppContextType, chat_id: str) -> str:
     """Get a specific chat room by ID.
 
     Retrieves detailed information about a single chat room.
@@ -97,7 +97,7 @@ async def get_chat(ctx: AppContextType, chat_id: str) -> str:
 
 
 @mcp.tool()
-async def create_chat(
+def create_chat(
     ctx: AppContextType,
     title: str,
     chat_type: str,
@@ -162,7 +162,7 @@ async def create_chat(
 
 
 @mcp.tool()
-async def update_chat(
+def update_chat(
     ctx: AppContextType,
     chat_id: str,
     title: Optional[str] = None,
@@ -212,7 +212,7 @@ async def update_chat(
 
 
 @mcp.tool()
-async def delete_chat(ctx: AppContextType, chat_id: str) -> str:
+def delete_chat(ctx: AppContextType, chat_id: str) -> str:
     """Delete a chat room.
 
     Permanently deletes a chat room. This action cannot be undone.

--- a/src/thenvoi_mcp/tools/messages.py
+++ b/src/thenvoi_mcp/tools/messages.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 @mcp.tool()
-async def list_chat_messages(
+def list_chat_messages(
     ctx: AppContextType,
     chat_id: str,
     page: Optional[int] = None,
@@ -118,7 +118,7 @@ async def list_chat_messages(
 
 
 @mcp.tool()
-async def create_chat_message(
+def create_chat_message(
     ctx: AppContextType,
     chat_id: str,
     content: str,

--- a/src/thenvoi_mcp/tools/participants.py
+++ b/src/thenvoi_mcp/tools/participants.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 @mcp.tool()
-async def list_chat_participants(
+def list_chat_participants(
     ctx: AppContextType,
     chat_id: str,
     participant_type: Optional[str] = None,
@@ -61,7 +61,7 @@ async def list_chat_participants(
 
 
 @mcp.tool()
-async def add_chat_participant(
+def add_chat_participant(
     ctx: AppContextType,
     chat_id: str,
     participant_id: str,
@@ -96,7 +96,7 @@ async def add_chat_participant(
 
 
 @mcp.tool()
-async def remove_chat_participant(
+def remove_chat_participant(
     ctx: AppContextType, chat_id: str, participant_id: str
 ) -> str:
     """Remove a participant from a chat room.
@@ -118,7 +118,7 @@ async def remove_chat_participant(
 
 
 @mcp.tool()
-async def list_available_participants(
+def list_available_participants(
     ctx: AppContextType,
     chat_id: str,
     participant_type: str,


### PR DESCRIPTION
**Issue Number 5**

The thenvoi SDK RestClient uses synchronous methods, so defining
MCP tools as async provided no benefit and added unnecessary overhead.

Changes:
- Convert all tool functions from async def to def in:
  - agents.py (4 functions)
  - chats.py (5 functions)
  - messages.py (2 functions)
  - participants.py (4 functions)
  - server.py (health_check)
- Update tests to use sync function calls
- Remove unused @pytest.mark.asyncio decorators and pytest imports