### PR TITLE
Add sse server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ requires-python = ">=3.11"
 dependencies = [
     "mcp[cli]>=1.2.0",
     "thenvoi-client-rest>=0.0.1",
+    "uvicorn>=0.30.0",  # Required for SSE transport mode
 ]
 
 [project.optional-dependencies]

--- a/src/thenvoi_mcp/config.py
+++ b/src/thenvoi_mcp/config.py
@@ -1,9 +1,19 @@
+from typing import Literal
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
+    # API configuration
     thenvoi_api_key: str = ""
     thenvoi_base_url: str = "https://app.thenvoi.com"
+
+    # Transport configuration
+    transport: Literal["stdio", "sse"] = "stdio"
+
+    # SSE server configuration (only used when transport="sse")
+    host: str = "127.0.0.1"
+    port: int = 8000
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/src/thenvoi_mcp/server.py
+++ b/src/thenvoi_mcp/server.py
@@ -1,3 +1,6 @@
+import argparse
+from typing import Literal
+
 from mcp.server.fastmcp import Context
 
 from thenvoi_mcp.config import settings
@@ -8,6 +11,8 @@ from thenvoi_mcp.tools import agents  # noqa: F401
 from thenvoi_mcp.tools import chats  # noqa: F401
 from thenvoi_mcp.tools import messages  # noqa: F401
 from thenvoi_mcp.tools import participants  # noqa: F401
+
+VERSION = "1.0.0"
 
 
 @mcp.tool()
@@ -31,12 +36,106 @@ def health_check(ctx: Context) -> str:
         return f"Health check failed: {str(e)}"
 
 
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Thenvoi MCP Server - Connect AI agents to Thenvoi platform",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Transport Modes:
+  stdio   Default mode for IDE integration (Cursor, Claude Desktop, etc.)
+          Communication via standard input/output streams.
+
+  sse     HTTP server mode for remote/Docker deployments.
+          Runs as a persistent HTTP service with Server-Sent Events.
+          Useful for cloud deployments, Docker containers, or shared
+          team environments where multiple clients connect to a single
+          server instance.
+
+Examples:
+  thenvoi-mcp                          # Run with STDIO (default)
+  thenvoi-mcp --transport sse          # Run as HTTP server on 127.0.0.1:8000
+  thenvoi-mcp --transport sse --port 3000 --host 0.0.0.0  # Custom host/port
+
+Environment Variables:
+  THENVOI_API_KEY       API key for Thenvoi platform (required)
+  THENVOI_BASE_URL      Base URL for Thenvoi API (default: https://app.thenvoi.com)
+  TRANSPORT             Transport mode: stdio or sse (default: stdio)
+  HOST                  Host to bind for SSE mode (default: 127.0.0.1)
+  PORT                  Port to bind for SSE mode (default: 8000)
+        """,
+    )
+
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"thenvoi-mcp {VERSION}",
+    )
+
+    parser.add_argument(
+        "--transport",
+        "-t",
+        type=str,
+        choices=["stdio", "sse"],
+        default=None,
+        help="Transport mode: stdio (default) or sse",
+    )
+
+    parser.add_argument(
+        "--host",
+        type=str,
+        default=None,
+        help="Host to bind for SSE mode (default: 127.0.0.1)",
+    )
+
+    parser.add_argument(
+        "--port",
+        "-p",
+        type=int,
+        default=None,
+        help="Port to bind for SSE mode (default: 8000)",
+    )
+
+    return parser.parse_args()
+
+
 def run() -> None:
-    """Run the MCP server with STDIO transport."""
-    logger.info("Starting thenvoi-mcp-server v1.0.0")
+    """Run the MCP server with configurable transport mode.
+
+    Supports two transport modes:
+    - STDIO (default): For IDE integration with Cursor, Claude Desktop, etc.
+    - SSE: For remote deployments, Docker containers, or shared team environments.
+
+    Configuration can be set via:
+    1. Command line arguments (highest priority)
+    2. Environment variables
+    3. Default values (lowest priority)
+    """
+    args = parse_args()
+
+    # Determine transport mode (CLI args override env vars)
+    transport: Literal["stdio", "sse"] = args.transport or settings.transport
+
+    # Update settings for SSE mode if CLI args provided
+    if args.host is not None:
+        mcp.settings.host = args.host
+    if args.port is not None:
+        mcp.settings.port = args.port
+
+    logger.info(f"Starting thenvoi-mcp-server v{VERSION}")
     logger.info(f"Base URL: {settings.thenvoi_base_url}")
-    logger.info("Server ready - listening for MCP protocol messages on STDIO")
-    mcp.run(transport="stdio")
+
+    if transport == "stdio":
+        logger.info("Transport: STDIO (for IDE integration)")
+        logger.info("Server ready - listening for MCP protocol messages on STDIO")
+        mcp.run(transport="stdio")
+    else:
+        host = args.host or settings.host
+        port = args.port or settings.port
+        logger.info("Transport: SSE (HTTP server mode)")
+        logger.info(f"Server ready - listening on http://{host}:{port}")
+        logger.info("SSE endpoint: /sse | Messages endpoint: /messages/")
+        mcp.run(transport="sse")
 
 
 if __name__ == "__main__":

--- a/src/thenvoi_mcp/shared.py
+++ b/src/thenvoi_mcp/shared.py
@@ -78,4 +78,9 @@ def serialize_response(result: Any, **kwargs) -> str:
     return json.dumps(result, indent=2, default=str)
 
 
-mcp = FastMCP(name="thenvoi-mcp-server", lifespan=app_lifespan)
+mcp = FastMCP(
+    name="thenvoi-mcp-server",
+    lifespan=app_lifespan,
+    host=settings.host,
+    port=settings.port,
+)

--- a/src/thenvoi_mcp/tools/chats.py
+++ b/src/thenvoi_mcp/tools/chats.py
@@ -125,6 +125,52 @@ def create_chat(
 
 
 @mcp.tool()
+def update_chat(
+    ctx: AppContextType,
+    chat_id: str,
+    title: Optional[str] = None,
+    status: Optional[str] = None,
+    metadata: Optional[str] = None,
+) -> str:
+    """Update an existing chat room.
+
+    Updates a chat room's configuration. Only the fields provided will be updated
+    (partial updates are supported). Fields not provided will remain unchanged.
+
+    Args:
+        chat_id: The unique identifier of the chat room to update (required).
+        title: New title for the chat room.
+        status: New status: 'active', 'archived', or 'closed'.
+        metadata: New JSON string containing metadata (will be parsed as JSON).
+
+    Returns:
+        Success message with the updated chat room's ID.
+    """
+    logger.debug(f"Updating chat: {chat_id}")
+    client = get_app_context(ctx).client
+
+    # Build request as dict to avoid sending null values
+    request_data: Dict[str, Any] = {}
+
+    if title is not None:
+        request_data["title"] = title
+
+    if status is not None:
+        request_data["status"] = status
+
+    if metadata is not None:
+        try:
+            request_data["metadata"] = json.loads(metadata)
+        except json.JSONDecodeError as e:
+            logger.error(f"Invalid JSON for metadata: {e}")
+            raise ValueError(f"Invalid JSON for metadata: {str(e)}")
+
+    client.chat_rooms.update_chat(id=chat_id, chat=cast(Any, request_data))
+    logger.info(f"Chat room updated successfully: {chat_id}")
+    return f"Chat room updated successfully: {chat_id}"
+
+
+@mcp.tool()
 def delete_chat(ctx: AppContextType, chat_id: str) -> str:
     """Delete a chat room.
 

--- a/uv.lock
+++ b/uv.lock
@@ -1662,6 +1662,7 @@ source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "thenvoi-client-rest" },
+    { name = "uvicorn" },
 ]
 
 [package.optional-dependencies]
@@ -1727,6 +1728,7 @@ requires-dist = [
     { name = "python-dotenv", marker = "extra == 'langgraph'", specifier = ">=1.0.0" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.20.0" },
     { name = "thenvoi-client-rest", specifier = ">=0.0.1" },
+    { name = "uvicorn", specifier = ">=0.30.0" },
 ]
 provides-extras = ["dev", "langgraph", "langchain", "examples"]
 


### PR DESCRIPTION
SSE Transport Support
Added dual transport mode to support both STDIO (for IDE integration) and SSE (for remote/Docker deployments). STDIO remains the default for local development with Cursor, Claude Desktop, etc. SSE enables running the MCP server as a persistent HTTP service - useful for cloud deployments, Docker containers, or shared team environments where multiple clients connect to a single server instance.