### PR TITLE
Fix: move checkout before token generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,11 @@ jobs:
     concurrency: release
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Generate GitHub App Token
         id: app_token_generator
         uses: thenvoi/thenvoi-envs/.github/actions/GithubToken@main
@@ -23,12 +28,6 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           installation_id: ${{ secrets.INSTALLATION_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ steps.app_token_generator.outputs.token }}
 
       - name: Release Please
         uses: googleapis/release-please-action@v4


### PR DESCRIPTION
The GithubToken action needs to be fetched from a repo, which requires checkout to happen first with the default GITHUB_TOKEN.