### PR TITLE
style: fix ruff formatting in generate_token.py

### DIFF
--- a/.github/actions/GithubToken/generate_token.py
+++ b/.github/actions/GithubToken/generate_token.py
@@ -4,9 +4,9 @@ import requests
 import os
 
 
-app_id = os.getenv('github_app_id')
-installation_id = os.getenv('github_app_installation_id')
-private_key = os.getenv('github_app_private_key')
+app_id = os.getenv("github_app_id")
+installation_id = os.getenv("github_app_installation_id")
+private_key = os.getenv("github_app_private_key")
 
 
 if not all([app_id, installation_id, private_key]):
@@ -15,22 +15,22 @@ if not all([app_id, installation_id, private_key]):
 
 now = int(time.time())
 payload = {
-    'iat': now,  # Issued at time
-    'exp': now + (10 * 60),  # JWT expiration time (10 minutes)
-    'iss': app_id  # GitHub App ID
+    "iat": now,  # Issued at time
+    "exp": now + (10 * 60),  # JWT expiration time (10 minutes)
+    "iss": app_id,  # GitHub App ID
 }
 
 try:
-    jwt_token = jwt.encode(payload, private_key, algorithm='RS256')
+    jwt_token = jwt.encode(payload, private_key, algorithm="RS256")
 except Exception as e:
     raise ValueError(f"Error encoding JWT: {e}")
 
 headers = {
-    'Authorization': f'Bearer {jwt_token}',
-    'Accept': 'application/vnd.github+json'
+    "Authorization": f"Bearer {jwt_token}",
+    "Accept": "application/vnd.github+json",
 }
 
-url = f'https://api.github.com/app/installations/{installation_id}/access_tokens'
+url = f"https://api.github.com/app/installations/{installation_id}/access_tokens"
 
 
 try:
@@ -42,7 +42,7 @@ except Exception as err:
     raise SystemExit(f"Other error occurred: {err}")  # Handle other errors
 
 # Extract and print the access token
-installation_access_token = response.json().get('token')
+installation_access_token = response.json().get("token")
 if installation_access_token:
     print(installation_access_token)
 else:


### PR DESCRIPTION
## Summary
- Fix ruff formatting in generate_token.py
- Use double quotes instead of single quotes
- Add trailing commas to dictionaries

This fixes the CI lint failure from PR #46.