### PR TITLE
fix: remove PyPI publishing from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,30 +37,6 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      - name: Set up Python
-        if: steps.release.outputs.release_created == 'true'
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install uv
-        if: steps.release.outputs.release_created == 'true'
-        uses: astral-sh/setup-uv@v4
-
-      - name: Install dependencies
-        if: steps.release.outputs.release_created == 'true'
-        run: uv sync --all-groups
-
-      - name: Build package
-        if: steps.release.outputs.release_created == 'true'
-        run: uv build
-
-      - name: Publish to PyPI
-        if: steps.release.outputs.release_created == 'true'
-        run: uv publish
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
-
       - name: Publish release summary
         if: steps.release.outputs.release_created == 'true'
         run: |


### PR DESCRIPTION
## Summary
- Remove Python setup, uv install, build, and PyPI publish steps from release workflow
- The MCP server is not published to PyPI

The release workflow will now only create GitHub releases with changelogs via release-please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)