### PR TITLE
fix(ci): Target main branch for release-please PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
           token: ${{ steps.app_token_generator.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: main
 
       - name: Publish release summary
         if: steps.release.outputs.release_created == 'true'


### PR DESCRIPTION
## Summary
- Add `target-branch: main` to release-please action
- Release-please defaults to the repo's default branch (`develop`), causing release PRs to incorrectly target `develop` instead of `main`
- This fixes the root cause of PR #63 failing

## Root cause
The repo's default branch is `develop`, but releases should come from `main`. Without explicit `target-branch`, release-please creates PRs against `develop`.

## Test plan
- [x] CI passes
- [ ] Close PR #63 (invalid release PR targeting develop)
- [ ] Next release workflow run should create PR targeting `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)