### PR TITLE
ci: skip PR title validation for all bot actors

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -11,8 +11,8 @@ jobs:
   validate:
     name: Validate PR Title
     runs-on: ubuntu-latest
-    # Skip validation for Dependabot, thenvoi-argocd, and release-please PRs
-    if: github.actor != 'dependabot[bot]' && github.actor != 'thenvoi-argocd' && github.actor != 'release-please[bot]'
+    # Skip validation for bot-created PRs
+    if: "!endsWith(github.actor, '[bot]')"
     steps:
       - name: Validate Conventional Commits format
         uses: amannn/action-semantic-pull-request@v6


### PR DESCRIPTION
## Summary
- Replace hardcoded bot actor list with a generic `endsWith(github.actor, '[bot]')` check
- Any GitHub bot (dependabot, release-please, renovate, etc.) will now skip PR title validation automatically

## Test plan
- [ ] Verify PR #86 (release-please) passes after merge
- [ ] Verify non-bot PRs still run title validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)