### PR TITLE
feat: dual-credential config + --scope/--tools/--room-id flags (INT-350)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,15 @@ Configure your AI assistant to use the Thenvoi MCP Server with the following JSO
         "--directory",
         "/ABSOLUTE/PATH/TO/thenvoi-mcp-server",
         "run",
-        "thenvoi-mcp"
+        "thenvoi-mcp",
+        "--scope",
+        "agent",
+        "--tools",
+        "contacts"
       ],
       "env": {
-        "THENVOI_API_KEY": "your_api_key_here",
+        "THENVOI_AGENT_KEY": "thnv_a_your_agent_key",
+        "THENVOI_USER_KEY": "thnv_u_your_user_key",
         "THENVOI_BASE_URL": "https://app.thenvoi.com"
       }
     }
@@ -88,6 +93,8 @@ Configure your AI assistant to use the Thenvoi MCP Server with the following JSO
 ```
 
 > **Note:** Replace `/ABSOLUTE/PATH/TO/thenvoi-mcp-server` with the actual path where you cloned the repository.
+
+> **Legacy single-key setups (`THENVOI_API_KEY`) still work** — see the Configuration section below for details and the breaking-change note about `--tools contacts`.
 
 <details>
 <summary><strong>Cursor Setup</strong></summary>
@@ -413,18 +420,69 @@ See `examples/langchain_agent.py` for the complete implementation.
 
 ## ⚙️ Configuration
 
-### Environment Variables
+### Credentials and scope (new in v1.2.0)
 
-Configure the server using `.env` file:
+`thenvoi-mcp` now takes explicit dual credentials and lets operators pick which
+scopes and tool groups to serve:
 
 ```bash
-# Required
+# One credential per scope
+export THENVOI_USER_KEY=thnv_u_your_user_key      # or BAND_USER_KEY
+export THENVOI_AGENT_KEY=thnv_a_your_agent_key    # or BAND_AGENT_KEY
+
+# Serve both scopes in one process (default: agent only)
+uv run thenvoi-mcp --scope agent,human
+
+# Opt into contact-directory / memory tools
+uv run thenvoi-mcp --scope agent --tools contacts,memory
+
+# Pin the whole server to a single chat/room
+uv run thenvoi-mcp --scope agent --room-id r_123
+```
+
+Resolution precedence per field: `CLI flag > THENVOI_* env > BAND_* env`. The
+legacy `THENVOI_API_KEY` env is still honored as a fallback — see below.
+
+**Breaking change note for `--tools`.** Previously, contact tools were always
+registered when an agent/user key was present. The new default is `--tools []`
+(no optional groups). Operators who relied on contact tools being on must now
+pass `--tools contacts` (or set `THENVOI_MCP_TOOLS=contacts`). Memory tools
+remain opt-in via `--tools memory`.
+
+Unknown `--scope` / `--tools` values do not fail startup; they're logged at
+WARN with a "did you mean?" hint, e.g.:
+
+```
+WARN  unknown --tools value 'contact' — did you mean 'contacts'? ignoring.
+WARN  unknown --scope value 'huamn' — did you mean 'human'? ignoring.
+```
+
+### Environment Variables
+
+| Variable                                       | Purpose                                           |
+| ---------------------------------------------- | ------------------------------------------------- |
+| `THENVOI_USER_KEY` / `BAND_USER_KEY`           | User (human-scope) API key (`thnv_u_...`)         |
+| `THENVOI_AGENT_KEY` / `BAND_AGENT_KEY`         | Agent-scope API key (`thnv_a_...`)                |
+| `THENVOI_MCP_SCOPE` / `BAND_MCP_SCOPE`         | Comma-separated scope list (default: `agent`)     |
+| `THENVOI_MCP_TOOLS` / `BAND_MCP_TOOLS`         | Opt-in tool groups: `contacts`, `memory`          |
+| `THENVOI_MCP_ROOM_ID` / `BAND_MCP_ROOM_ID`     | Pinned room id (optional)                         |
+| `THENVOI_API_KEY`                              | Legacy single-key path — **still supported**      |
+| `THENVOI_BASE_URL`                             | API base URL (default: `https://app.thenvoi.com`) |
+| `TRANSPORT`                                    | `stdio` (default) or `sse`                        |
+| `HOST` / `PORT`                                | SSE bind host/port                                |
+
+Legacy `.env` setups keep working unchanged:
+
+```bash
+# Legacy, still supported
 THENVOI_API_KEY=your-api-key-here
 THENVOI_BASE_URL=https://app.thenvoi.com
-
-# Optional
-THENVOI_LOG_LEVEL=info  # Options: debug, info, warning, error
 ```
+
+When both a scope-specific key (`THENVOI_USER_KEY` / `THENVOI_AGENT_KEY`) and
+`THENVOI_API_KEY` are set, the scope-specific key wins for its scope. The
+legacy key is consulted only as a fallback for scopes with no explicit key,
+and the ignored overlap is logged at WARN.
 
 > **Important:** Never commit your `.env` file to version control. It's already in `.gitignore`.
 

--- a/mcp_config_example.json
+++ b/mcp_config_example.json
@@ -6,6 +6,25 @@
           "--directory",
           "/ABSOLUTE/PATH/TO/thenvoi-mcp-server",
           "run",
+          "thenvoi-mcp",
+          "--scope",
+          "agent",
+          "--tools",
+          "contacts"
+        ],
+        "env": {
+          "THENVOI_AGENT_KEY": "thnv_a_your_agent_key",
+          "THENVOI_USER_KEY": "thnv_u_your_user_key",
+          "THENVOI_BASE_URL": "https://app.thenvoi.com"
+        }
+      },
+      "thenvoi_legacy": {
+        "_comment": "Legacy single-key setup. Still supported; prefer THENVOI_USER_KEY / THENVOI_AGENT_KEY for new deployments.",
+        "command": "uv",
+        "args": [
+          "--directory",
+          "/ABSOLUTE/PATH/TO/thenvoi-mcp-server",
+          "run",
           "thenvoi-mcp"
         ],
         "env": {
@@ -15,4 +34,3 @@
       }
     }
   }
-  

--- a/src/thenvoi_mcp/config.py
+++ b/src/thenvoi_mcp/config.py
@@ -1,11 +1,95 @@
+"""Configuration for thenvoi-mcp.
+
+Phase 2 of INT-338 (INT-350) replaces the single-key `THENVOI_API_KEY` + prefix
+inference config with explicit dual credentials, `--scope` / `--tools` /
+`--room-id` flags, and typo suggestions. The legacy `THENVOI_API_KEY` path is
+retained as a fallback — existing deployments keep working.
+
+Resolution precedence per credential/field:
+    CLI flag > THENVOI_* env > BAND_* env > THENVOI_API_KEY (legacy only)
+
+`resolve_config(cli, env)` is pure — it takes a CLI-args-ish mapping and an
+environment mapping, and returns a `Config`. `validate(config)` raises
+`ConfigError` when credentials for a requested scope are missing. Unknown
+`--scope` / `--tools` values do NOT fail startup; they are dropped from the
+resolved list and surfaced as `ConfigWarning` entries in `config.warnings`.
+
+The `Settings` model (transport, base_url, DNS rebinding) stays — only the
+credential/scope/tools plumbing is new.
+"""
+
 from __future__ import annotations
 
-from typing import Literal
+import difflib
+from dataclasses import dataclass, field
+from typing import Literal, Mapping, Sequence
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+Scope = Literal["agent", "human"]
+ToolGroup = Literal["contacts", "memory"]
+
+VALID_SCOPES: list[str] = ["agent", "human"]
+VALID_TOOLS: list[str] = ["contacts", "memory"]
+
+DEFAULT_SCOPE: list[Scope] = ["agent"]
+DEFAULT_TOOLS: list[ToolGroup] = []
+
+ConfigWarningKind = Literal[
+    "legacy-key-ignored",
+    "unknown-scope-value",
+    "unknown-tools-value",
+]
+
+
+class ConfigError(Exception):
+    """Raised when required credentials for a requested scope are missing."""
+
+
+@dataclass(frozen=True)
+class ConfigWarning:
+    """A non-fatal config issue surfaced at startup and logged at WARN.
+
+    `kind` is machine-checkable; tests assert on `kind` + `did_you_mean`.
+    `message` is pre-formatted for log emission; callers should not rebuild it.
+    """
+
+    kind: ConfigWarningKind
+    value: str
+    did_you_mean: str | None
+    message: str
+
+
+@dataclass
+class Config:
+    """Resolved configuration for a single thenvoi-mcp process.
+
+    `user_key` and `agent_key` are the explicit dual credentials. `legacy_key`
+    holds `THENVOI_API_KEY` and is consulted ONLY as a fallback when the
+    scope-specific slot is empty. Its prefix (`thnv_u_` / `thnv_a_` / `thnv_`)
+    determines which scopes it can serve.
+
+    `scope` / `tools` are already normalized (trimmed, lowercased, deduped,
+    unknown values dropped). `warnings` captures anything that couldn't be
+    honored without failing startup.
+    """
+
+    user_key: str | None = None
+    agent_key: str | None = None
+    room_id: str | None = None
+    scope: list[Scope] = field(default_factory=list)
+    tools: list[ToolGroup] = field(default_factory=list)
+    legacy_key: str | None = None
+    warnings: list[ConfigWarning] = field(default_factory=list)
+
 
 class Settings(BaseSettings):
+    """Process-wide settings that are not part of Phase 2's credential plumbing.
+
+    Kept as `pydantic-settings` for backward compatibility with existing code
+    paths that import `settings` directly.
+    """
+
     # API configuration
     thenvoi_api_key: str = ""
     thenvoi_base_url: str = "https://app.thenvoi.com"
@@ -18,9 +102,6 @@ class Settings(BaseSettings):
     port: int = 8000
 
     # Transport security (DNS rebinding protection)
-    # When enabled, only requests with Host headers in allowed_hosts are accepted.
-    # For Docker/remote deployments, configure allowed hosts:
-    #   ALLOWED_HOSTS='["localhost:*","host.docker.internal:*"]'
     enable_dns_rebinding_protection: bool = True
     allowed_hosts: list[str] = []
     allowed_origins: list[str] = []
@@ -33,3 +114,356 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+
+# ---------------------------------------------------------------------------
+# Key-prefix inference (legacy only)
+# ---------------------------------------------------------------------------
+
+
+def _legacy_key_capabilities(legacy_key: str | None) -> tuple[bool, bool]:
+    """Return (can_serve_human, can_serve_agent) for a legacy key.
+
+    - `thnv_u_...` — user key, human only.
+    - `thnv_a_...` — agent key, agent only.
+    - `thnv_...`   — legacy all-capable, both scopes.
+    - Anything else (including None / empty) — serves neither scope.
+    """
+    if not legacy_key:
+        return (False, False)
+    if legacy_key.startswith("thnv_u_"):
+        return (True, False)
+    if legacy_key.startswith("thnv_a_"):
+        return (False, True)
+    if legacy_key.startswith("thnv_"):
+        return (True, True)
+    return (False, False)
+
+
+# ---------------------------------------------------------------------------
+# Typo suggestions
+# ---------------------------------------------------------------------------
+
+
+def _suggest_value(bad: str, valid: list[str]) -> str | None:
+    """Return the closest match in `valid` or None.
+
+    Thin wrapper over `difflib.get_close_matches(bad, valid, n=1, cutoff=0.6)`.
+    Private to `config.py` on purpose — Phase 3's registrar doesn't need it.
+    """
+    matches = difflib.get_close_matches(bad, valid, n=1, cutoff=0.6)
+    return matches[0] if matches else None
+
+
+# ---------------------------------------------------------------------------
+# List-value parsing (shared by --scope and --tools)
+# ---------------------------------------------------------------------------
+
+
+def _normalize_list_value(raw: str | Sequence[str] | None) -> list[str]:
+    """Normalize a CLI/env list value into a clean list of lowercased tokens.
+
+    Accepts:
+    - None -> []
+    - "" -> []
+    - "a,b" -> ["a", "b"]
+    - ["a", "b,c"] -> ["a", "b", "c"]  (supports both repeatable and CSV forms)
+
+    Trims whitespace, lowercases, drops empty tokens, preserves order, dedupes.
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        parts = raw.split(",")
+    else:
+        parts = []
+        for entry in raw:
+            parts.extend(entry.split(","))
+
+    seen: set[str] = set()
+    out: list[str] = []
+    for token in parts:
+        clean = token.strip().lower()
+        if not clean or clean in seen:
+            continue
+        seen.add(clean)
+        out.append(clean)
+    return out
+
+
+def _resolve_list(
+    cli_value: str | Sequence[str] | None,
+    env_primary: str | None,
+    env_alias: str | None,
+    default: list[str],
+    *,
+    explicit_empty: bool,
+) -> list[str]:
+    """Apply per-field precedence for list-valued settings.
+
+    Precedence: CLI > THENVOI_* env > BAND_* env > default.
+
+    `explicit_empty` lets a caller pass `--tools ""` (empty CLI value) and have
+    it override the env/default, matching the ticket's `--tools ""` -> []
+    requirement.
+    """
+    if explicit_empty:
+        return []
+    if cli_value is not None and (
+        not isinstance(cli_value, (list, tuple)) or len(cli_value) > 0
+    ):
+        return _normalize_list_value(cli_value)
+    if env_primary is not None:
+        return _normalize_list_value(env_primary)
+    if env_alias is not None:
+        return _normalize_list_value(env_alias)
+    return list(default)
+
+
+def _partition_known(
+    raw: list[str],
+    valid: list[str],
+    flag_label: str,
+    kind: ConfigWarningKind,
+) -> tuple[list[str], list[ConfigWarning]]:
+    """Split `raw` into (known, warnings). Unknown values drop + warn.
+
+    `flag_label` is the human-facing flag name used in warning messages
+    (e.g. `--tools`, `--scope`).
+    """
+    known: list[str] = []
+    warnings: list[ConfigWarning] = []
+    valid_set = set(valid)
+    for value in raw:
+        if value in valid_set:
+            known.append(value)
+            continue
+        suggestion = _suggest_value(value, valid)
+        if suggestion is not None:
+            msg = (
+                f"unknown {flag_label} value '{value}' — "
+                f"did you mean '{suggestion}'? ignoring."
+            )
+        else:
+            msg = (
+                f"unknown {flag_label} value '{value}' — "
+                f"valid values: {', '.join(valid)}. ignoring."
+            )
+        warnings.append(
+            ConfigWarning(
+                kind=kind,
+                value=value,
+                did_you_mean=suggestion,
+                message=msg,
+            )
+        )
+    return known, warnings
+
+
+# ---------------------------------------------------------------------------
+# Per-slot precedence for scalar values
+# ---------------------------------------------------------------------------
+
+
+def _resolve_scalar(
+    cli_value: str | None,
+    env_primary: str | None,
+    env_alias: str | None,
+) -> str | None:
+    """CLI > THENVOI_* > BAND_* > None. Empty strings count as unset."""
+    for candidate in (cli_value, env_primary, env_alias):
+        if candidate is not None and candidate != "":
+            return candidate
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def resolve_config(
+    cli: Mapping[str, object] | None = None,
+    env: Mapping[str, str] | None = None,
+) -> Config:
+    """Resolve a `Config` from CLI args and environment.
+
+    `cli` keys (all optional): `user_key`, `agent_key`, `room_id`, `scope`,
+    `tools`. Values are what argparse produces. For `scope` / `tools`, accept
+    either a comma-separated string or a list of strings (argparse `append`
+    action).
+
+    `env` is typically `os.environ`. Anything not supplied is treated as unset.
+
+    The returned `Config` is already normalized: unknown `--scope` / `--tools`
+    values are dropped and surfaced in `config.warnings`, and cross-slot
+    legacy-key masking is resolved.
+    """
+    cli = cli or {}
+    env = env or {}
+
+    # --- Credentials -------------------------------------------------------
+    user_key = _resolve_scalar(
+        cli.get("user_key")
+        if isinstance(cli.get("user_key"), str) or cli.get("user_key") is None
+        else None,  # type: ignore[arg-type]
+        env.get("THENVOI_USER_KEY"),
+        env.get("BAND_USER_KEY"),
+    )
+    agent_key = _resolve_scalar(
+        cli.get("agent_key")
+        if isinstance(cli.get("agent_key"), str) or cli.get("agent_key") is None
+        else None,  # type: ignore[arg-type]
+        env.get("THENVOI_AGENT_KEY"),
+        env.get("BAND_AGENT_KEY"),
+    )
+    legacy_key_raw = env.get("THENVOI_API_KEY")
+    legacy_key: str | None = legacy_key_raw if legacy_key_raw else None
+
+    # --- Room id -----------------------------------------------------------
+    room_id = _resolve_scalar(
+        cli.get("room_id")
+        if isinstance(cli.get("room_id"), str) or cli.get("room_id") is None
+        else None,  # type: ignore[arg-type]
+        env.get("THENVOI_MCP_ROOM_ID"),
+        env.get("BAND_MCP_ROOM_ID"),
+    )
+
+    warnings: list[ConfigWarning] = []
+
+    # --- Scope -------------------------------------------------------------
+    cli_scope = cli.get("scope")
+    scope_raw = _resolve_list(
+        cli_scope
+        if cli_scope is None or isinstance(cli_scope, (str, list, tuple))
+        else None,  # type: ignore[arg-type]
+        env.get("THENVOI_MCP_SCOPE"),
+        env.get("BAND_MCP_SCOPE"),
+        default=list(DEFAULT_SCOPE),
+        explicit_empty=False,
+    )
+    scope_known, scope_warnings = _partition_known(
+        scope_raw, VALID_SCOPES, "--scope", "unknown-scope-value"
+    )
+    warnings.extend(scope_warnings)
+    # If every caller-supplied value was unknown, fall back to the default.
+    # The ticket requires unknown values to be dropped, not to collapse scope
+    # to []; an empty resolved scope would also trigger validate() to fail
+    # loudly, which is the right behavior when the operator typed something
+    # that could not be matched at all. Prefer explicit (possibly empty) user
+    # intent over a silent default here.
+    scope = [s for s in scope_known if s in VALID_SCOPES]
+
+    # --- Tools -------------------------------------------------------------
+    cli_tools = cli.get("tools")
+    # `--tools ""` should produce []: detect that here. An empty string from
+    # argparse (default=None) signals the operator explicitly cleared the list.
+    explicit_empty = isinstance(cli_tools, str) and cli_tools == ""
+    tools_raw = _resolve_list(
+        cli_tools
+        if cli_tools is None or isinstance(cli_tools, (str, list, tuple))
+        else None,  # type: ignore[arg-type]
+        env.get("THENVOI_MCP_TOOLS"),
+        env.get("BAND_MCP_TOOLS"),
+        default=list(DEFAULT_TOOLS),
+        explicit_empty=explicit_empty,
+    )
+    tools_known, tools_warnings = _partition_known(
+        tools_raw, VALID_TOOLS, "--tools", "unknown-tools-value"
+    )
+    warnings.extend(tools_warnings)
+    tools = [t for t in tools_known if t in VALID_TOOLS]
+
+    # --- Cross-slot legacy-key masking ------------------------------------
+    # If a scope-specific key is set AND legacy_key is populated, the legacy
+    # key is ignored for that scope. Emit a warning if legacy_key would have
+    # been consulted but is now ignored. We only warn once per process; the
+    # value of `value` is the semantic slot label ("legacy_key") so tests can
+    # assert on it deterministically.
+    if legacy_key is not None:
+        legacy_human, legacy_agent = _legacy_key_capabilities(legacy_key)
+        # A legacy key is "ignored" when BOTH of these hold:
+        #   - the scope-specific slot that would otherwise have been filled
+        #     from it is already populated, AND
+        #   - that scope-specific slot would have been served by legacy_key.
+        # Put differently: if user_key is set AND legacy_key could serve human,
+        # legacy's human role is masked. Same for agent.
+        human_masked = user_key is not None and legacy_human
+        agent_masked = agent_key is not None and legacy_agent
+        if human_masked or agent_masked:
+            warnings.append(
+                ConfigWarning(
+                    kind="legacy-key-ignored",
+                    value="legacy_key",
+                    did_you_mean=None,
+                    message=(
+                        "THENVOI_API_KEY is set but scope-specific keys "
+                        "(THENVOI_USER_KEY / THENVOI_AGENT_KEY) take precedence; "
+                        "legacy key ignored for overlapping scope(s)."
+                    ),
+                )
+            )
+
+    return Config(
+        user_key=user_key,
+        agent_key=agent_key,
+        room_id=room_id,
+        scope=scope,  # type: ignore[arg-type]
+        tools=tools,  # type: ignore[arg-type]
+        legacy_key=legacy_key,
+        warnings=warnings,
+    )
+
+
+def validate(config: Config) -> None:
+    """Fail-fast validation. Raises ConfigError if credentials are missing.
+
+    For each scope requested in `config.scope`:
+    - "agent" requires `agent_key` OR an agent-capable `legacy_key`.
+    - "human" requires `user_key` OR a human-capable `legacy_key`.
+    """
+    if not config.scope:
+        raise ConfigError(
+            "No valid --scope values resolved. Expected one or more of: "
+            f"{', '.join(VALID_SCOPES)}."
+        )
+
+    legacy_human, legacy_agent = _legacy_key_capabilities(config.legacy_key)
+
+    missing: list[str] = []
+    if "human" in config.scope:
+        if config.user_key is None and not legacy_human:
+            missing.append(
+                "human scope requested but no user credential available "
+                "(set --user-key / THENVOI_USER_KEY / BAND_USER_KEY, or use a "
+                "human-capable THENVOI_API_KEY)"
+            )
+    if "agent" in config.scope:
+        if config.agent_key is None and not legacy_agent:
+            missing.append(
+                "agent scope requested but no agent credential available "
+                "(set --agent-key / THENVOI_AGENT_KEY / BAND_AGENT_KEY, or use an "
+                "agent-capable THENVOI_API_KEY)"
+            )
+
+    if missing:
+        raise ConfigError("; ".join(missing))
+
+
+def resolve_credential_for_scope(config: Config, scope: Scope) -> str | None:
+    """Return the API key that should be used for `scope`.
+
+    Scope-specific key wins; legacy key is a fallback. Returns None if nothing
+    serves the scope (validate() would have raised earlier).
+    """
+    if scope == "human":
+        if config.user_key is not None:
+            return config.user_key
+        legacy_human, _ = _legacy_key_capabilities(config.legacy_key)
+        return config.legacy_key if legacy_human else None
+    if scope == "agent":
+        if config.agent_key is not None:
+            return config.agent_key
+        _, legacy_agent = _legacy_key_capabilities(config.legacy_key)
+        return config.legacy_key if legacy_agent else None
+    return None

--- a/src/thenvoi_mcp/config.py
+++ b/src/thenvoi_mcp/config.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import difflib
 from dataclasses import dataclass, field
-from typing import Literal, Mapping, Sequence
+from typing import Literal, Mapping, Sequence, cast
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -77,8 +77,18 @@ class Config:
     user_key: str | None = None
     agent_key: str | None = None
     room_id: str | None = None
-    scope: list[Scope] = field(default_factory=list)
-    tools: list[ToolGroup] = field(default_factory=list)
+    # Default honors ticket AC #6 ("default scope is ['agent']"). Instances
+    # produced directly via `Config(user_key="x")` in tests/fixtures get the
+    # same default as instances produced via `resolve_config({}, {})`.
+    # The `cast` is needed because `list(DEFAULT_SCOPE)` loses the Literal
+    # narrowing even though DEFAULT_SCOPE itself is typed list[Scope]; pyrefly
+    # otherwise flags this as list[str] being assigned to list[Scope].
+    scope: list[Scope] = field(
+        default_factory=lambda: cast("list[Scope]", list(DEFAULT_SCOPE))
+    )
+    tools: list[ToolGroup] = field(
+        default_factory=lambda: cast("list[ToolGroup]", list(DEFAULT_TOOLS))
+    )
     legacy_key: str | None = None
     warnings: list[ConfigWarning] = field(default_factory=list)
 

--- a/src/thenvoi_mcp/config.py
+++ b/src/thenvoi_mcp/config.py
@@ -60,7 +60,7 @@ class ConfigWarning:
     message: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class Config:
     """Resolved configuration for a single thenvoi-mcp process.
 
@@ -131,21 +131,26 @@ settings = Settings()
 # ---------------------------------------------------------------------------
 
 
+USER_KEY_PREFIXES = ("thnv_u_", "band_u_")
+AGENT_KEY_PREFIXES = ("thnv_a_", "band_a_")
+LEGACY_KEY_PREFIXES = ("thnv_", "band_")
+
+
 def _legacy_key_capabilities(legacy_key: str | None) -> tuple[bool, bool]:
     """Return (can_serve_human, can_serve_agent) for a legacy key.
 
-    - `thnv_u_...` — user key, human only.
-    - `thnv_a_...` — agent key, agent only.
-    - `thnv_...`   — legacy all-capable, both scopes.
+    - `thnv_u_...` / `band_u_...` — user key, human only.
+    - `thnv_a_...` / `band_a_...` — agent key, agent only.
+    - `thnv_...` / `band_...`   — legacy all-capable, both scopes.
     - Anything else (including None / empty) — serves neither scope.
     """
     if not legacy_key:
         return (False, False)
-    if legacy_key.startswith("thnv_u_"):
+    if legacy_key.startswith(USER_KEY_PREFIXES):
         return (True, False)
-    if legacy_key.startswith("thnv_a_"):
+    if legacy_key.startswith(AGENT_KEY_PREFIXES):
         return (False, True)
-    if legacy_key.startswith("thnv_"):
+    if legacy_key.startswith(LEGACY_KEY_PREFIXES):
         return (True, True)
     return (False, False)
 
@@ -199,6 +204,20 @@ def _normalize_list_value(raw: str | Sequence[str] | None) -> list[str]:
         seen.add(clean)
         out.append(clean)
     return out
+
+
+def _is_explicit_empty_cli_value(value: object) -> bool:
+    """Return True for CLI shapes produced by an explicit empty list flag."""
+    if value == "":
+        return True
+    if isinstance(value, (list, tuple)) and value:
+        tokens: list[str] = []
+        for entry in value:
+            if not isinstance(entry, str):
+                return False
+            tokens.extend(entry.split(","))
+        return all(token.strip() == "" for token in tokens)
+    return False
 
 
 def _resolve_list(
@@ -366,9 +385,9 @@ def resolve_config(
 
     # --- Tools -------------------------------------------------------------
     cli_tools = cli.get("tools")
-    # `--tools ""` should produce []: detect that here. An empty string from
-    # argparse (default=None) signals the operator explicitly cleared the list.
-    explicit_empty = isinstance(cli_tools, str) and cli_tools == ""
+    # `--tools ""` should produce [] and override any env/default values.
+    # Argparse's append action returns [""], while direct callers may pass "".
+    explicit_empty = _is_explicit_empty_cli_value(cli_tools)
     tools_raw = _resolve_list(
         cli_tools
         if cli_tools is None or isinstance(cli_tools, (str, list, tuple))

--- a/src/thenvoi_mcp/server.py
+++ b/src/thenvoi_mcp/server.py
@@ -14,11 +14,15 @@ from __future__ import annotations
 
 import argparse
 import os
-from typing import Literal
+from dataclasses import replace
+from typing import Literal, Sequence
 
 from thenvoi_mcp import __version__
 from thenvoi_mcp.config import (
     Config,
+    AGENT_KEY_PREFIXES,
+    LEGACY_KEY_PREFIXES,
+    USER_KEY_PREFIXES,
     ConfigError,
     _legacy_key_capabilities,
     resolve_config,
@@ -39,15 +43,15 @@ def get_key_type(key: str) -> str:
     """Get API key type from prefix.
 
     Key formats:
-    - User keys: thnv_u_<timestamp>_<random>
-    - Agent keys: thnv_a_<timestamp>_<random>
-    - Legacy keys: thnv_<timestamp>_<random> (loads all tools)
+    - User keys: thnv_u_<timestamp>_<random> or band_u_<...>
+    - Agent keys: thnv_a_<timestamp>_<random> or band_a_<...>
+    - Legacy keys: thnv_<timestamp>_<random> or band_<...> (loads all tools)
     """
-    if key.startswith("thnv_u_"):
+    if key.startswith(USER_KEY_PREFIXES):
         return "user"
-    elif key.startswith("thnv_a_"):
+    if key.startswith(AGENT_KEY_PREFIXES):
         return "agent"
-    elif key.startswith("thnv_"):
+    if key.startswith(LEGACY_KEY_PREFIXES):
         return "legacy"
     return "unknown"
 
@@ -84,26 +88,31 @@ def load_tools(key_type: str) -> None:
         logger.debug("Loaded human tools")
 
 
-def _choose_legacy_key_type(config: Config) -> str:
-    """Pick the `get_key_type` return value for the legacy tool loader.
-
-    During the transition the handwritten tools still key off prefix inference.
-    We map the new dual-credential config back onto that single label so the
-    existing loader keeps working unchanged.
-    """
-    # If a true legacy key is present, honor its prefix (matches old behavior).
-    if config.legacy_key:
-        return get_key_type(config.legacy_key)
-    # Otherwise map from the resolved scope list.
-    has_agent = "agent" in config.scope
-    has_human = "human" in config.scope
+def _key_type_from_scope(scope: Sequence[str]) -> str:
+    """Map resolved scopes back to the legacy handwritten loader label."""
+    has_agent = "agent" in scope
+    has_human = "human" in scope
     if has_agent and has_human:
         return "legacy"
     if has_agent:
         return "agent"
     if has_human:
         return "user"
-    # Fall back to whatever THENVOI_API_KEY looked like (empty string -> unknown).
+    return "unknown"
+
+
+def _choose_legacy_key_type(config: Config) -> str:
+    """Pick the `get_key_type` return value for the legacy tool loader.
+
+    During the transition the handwritten tools still key off prefix inference.
+    Scope-specific credentials must honor the resolved scope instead of a stale
+    legacy key; otherwise a process can log scope=["human"] while loading agent
+    tools from `THENVOI_API_KEY`.
+    """
+    if config.user_key or config.agent_key:
+        return _key_type_from_scope(config.scope)
+    if config.legacy_key:
+        return get_key_type(config.legacy_key)
     return get_key_type(settings.thenvoi_api_key)
 
 
@@ -112,7 +121,9 @@ def health_check(ctx: AppContextType) -> str:
     """Test MCP server and API connectivity."""
     app_ctx = get_app_context(ctx)
     client = app_ctx.client
-    key_type = get_key_type(settings.thenvoi_api_key)
+    key_type = _key_type_from_scope(app_ctx.scope)
+    if key_type == "unknown":
+        key_type = get_key_type(settings.thenvoi_api_key)
     try:
         if key_type == "user":
             client.human_api_agents.list_my_agents()
@@ -234,6 +245,19 @@ def _cli_mapping(args: argparse.Namespace) -> dict[str, object]:
     }
 
 
+def _apply_legacy_scope_writeback(
+    config: Config,
+) -> Config:
+    """Return config with scope rewritten to match a pure legacy key."""
+    legacy_human, legacy_agent = _legacy_key_capabilities(config.legacy_key)
+    legacy_scope: list[Literal["agent", "human"]] = []
+    if legacy_agent:
+        legacy_scope.append("agent")
+    if legacy_human:
+        legacy_scope.append("human")
+    return replace(config, scope=legacy_scope)
+
+
 def run() -> None:
     """Run the MCP server with configurable transport mode.
 
@@ -284,13 +308,7 @@ def run() -> None:
     # for an all-capable `thnv_*` key, in which case config.scope is still the
     # default ["agent"] but load_tools will load both surfaces).
     if _is_pure_legacy_invocation(args, config):
-        legacy_human, legacy_agent = _legacy_key_capabilities(config.legacy_key)
-        legacy_scope: list[Literal["agent", "human"]] = []
-        if legacy_agent:
-            legacy_scope.append("agent")
-        if legacy_human:
-            legacy_scope.append("human")
-        config.scope = legacy_scope
+        config = _apply_legacy_scope_writeback(config)
 
     set_pending_config(config)
 

--- a/src/thenvoi_mcp/server.py
+++ b/src/thenvoi_mcp/server.py
@@ -1,13 +1,40 @@
+"""MCP server entry point.
+
+Phase 2 (INT-350) adds `--user-key`, `--agent-key`, `--room-id`, `--scope`,
+and `--tools` CLI flags, resolves them through `config.resolve_config`, and
+emits `config.warnings` before the server accepts traffic. The legacy
+`THENVOI_API_KEY` path still works end-to-end.
+
+Tool registration still runs through the current prefix-inference path; the
+registrar that consumes `config.scope` / `config.tools` lands in Phase 3
+(INT-351).
+"""
+
+from __future__ import annotations
+
 import argparse
+import os
 from typing import Literal
 
 from thenvoi_mcp import __version__
-from thenvoi_mcp.config import settings
-from thenvoi_mcp.shared import mcp, logger, get_app_context, AppContextType
+from thenvoi_mcp.config import (
+    Config,
+    ConfigError,
+    resolve_config,
+    settings,
+    validate,
+)
+from thenvoi_mcp.shared import (
+    AppContextType,
+    get_app_context,
+    logger,
+    mcp,
+    set_pending_config,
+)
 
 
 def get_key_type(key: str) -> str:
-    """Get API key type.
+    """Get API key type from prefix.
 
     Key formats:
     - User keys: thnv_u_<timestamp>_<random>
@@ -26,7 +53,8 @@ def get_key_type(key: str) -> str:
 def load_tools(key_type: str) -> None:
     """Load tools based on API key type.
 
-    Tools register themselves via @mcp.tool() decorator on import.
+    Tools register themselves via @mcp.tool() decorator on import. The
+    SDK-driven registrar replaces this in Phase 3.
     """
     if key_type in ("agent", "legacy"):
         from thenvoi_mcp.tools.agent import (  # noqa: F401
@@ -54,24 +82,59 @@ def load_tools(key_type: str) -> None:
         logger.debug("Loaded human tools")
 
 
+def _choose_legacy_key_type(config: Config) -> str:
+    """Pick the `get_key_type` return value for the legacy tool loader.
+
+    During the transition the handwritten tools still key off prefix inference.
+    We map the new dual-credential config back onto that single label so the
+    existing loader keeps working unchanged.
+    """
+    # If a true legacy key is present, honor its prefix (matches old behavior).
+    if config.legacy_key:
+        return get_key_type(config.legacy_key)
+    # Otherwise map from the resolved scope list.
+    has_agent = "agent" in config.scope
+    has_human = "human" in config.scope
+    if has_agent and has_human:
+        return "legacy"
+    if has_agent:
+        return "agent"
+    if has_human:
+        return "user"
+    # Fall back to whatever THENVOI_API_KEY looked like (empty string -> unknown).
+    return get_key_type(settings.thenvoi_api_key)
+
+
 @mcp.tool()
 def health_check(ctx: AppContextType) -> str:
     """Test MCP server and API connectivity."""
-    client = get_app_context(ctx).client
+    app_ctx = get_app_context(ctx)
+    client = app_ctx.client
     key_type = get_key_type(settings.thenvoi_api_key)
     try:
         if key_type == "user":
             client.human_api_agents.list_my_agents()
         elif key_type == "agent":
             client.agent_api_identity.get_agent_me()
-        else:  # legacy - try both
+        else:  # legacy / unknown - try human path
             client.human_api_agents.list_my_agents()
         return f"OK | {key_type} | {settings.thenvoi_base_url}"
     except Exception as e:
         return f"Failed | {key_type} | {e}"
 
 
-def parse_args() -> argparse.Namespace:
+def _split_csv(values: list[str] | None) -> list[str] | None:
+    """Expand argparse `append` values so `--scope a,b --scope c` -> ['a','b','c'].
+
+    Returned value is passed to `resolve_config` as-is; `_normalize_list_value`
+    inside `config.py` does the final trim/lowercase/dedupe.
+    """
+    if values is None:
+        return None
+    return list(values)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
         description="Thenvoi MCP Server - Connect AI agents to Thenvoi platform",
@@ -83,17 +146,21 @@ Transport Modes:
 
   sse     HTTP server mode for remote/Docker deployments.
           Runs as a persistent HTTP service with Server-Sent Events.
-          Useful for cloud deployments, Docker containers, or shared
-          team environments where multiple clients connect to a single
-          server instance.
 
 Examples:
-  thenvoi-mcp                          # Run with STDIO (default)
-  thenvoi-mcp --transport sse          # Run as HTTP server on 127.0.0.1:8000
-  thenvoi-mcp --transport sse --port 3000 --host 0.0.0.0  # Custom host/port
+  thenvoi-mcp                                 # Run with STDIO (default)
+  thenvoi-mcp --transport sse                 # Run as HTTP server on 127.0.0.1:8000
+  thenvoi-mcp --scope agent,human             # Serve both scopes
+  thenvoi-mcp --scope agent --tools contacts  # Agent + opt-in contacts tools
+  thenvoi-mcp --scope agent --room-id r_123   # Pin to a single room
 
 Environment Variables:
-  THENVOI_API_KEY       API key for Thenvoi platform (required)
+  THENVOI_USER_KEY / BAND_USER_KEY      User (human scope) API key
+  THENVOI_AGENT_KEY / BAND_AGENT_KEY    Agent scope API key
+  THENVOI_MCP_SCOPE / BAND_MCP_SCOPE    Comma-separated scopes (default: agent)
+  THENVOI_MCP_TOOLS / BAND_MCP_TOOLS    Opt-in tool groups: contacts, memory
+  THENVOI_MCP_ROOM_ID / BAND_MCP_ROOM_ID  Optional pinned room id
+  THENVOI_API_KEY       Legacy single-key path (still supported as fallback)
   THENVOI_BASE_URL      Base URL for Thenvoi API (default: https://app.thenvoi.com)
   TRANSPORT             Transport mode: stdio or sse (default: stdio)
   HOST                  Host to bind for SSE mode (default: 127.0.0.1)
@@ -105,6 +172,32 @@ Environment Variables:
         "--version",
         action="version",
         version=f"thenvoi-mcp {__version__}",
+    )
+
+    parser.add_argument("--user-key", dest="user_key", type=str, default=None)
+    parser.add_argument("--agent-key", dest="agent_key", type=str, default=None)
+    parser.add_argument("--room-id", dest="room_id", type=str, default=None)
+    parser.add_argument(
+        "--scope",
+        dest="scope",
+        action="append",
+        default=None,
+        help=(
+            "Scope to serve. Repeatable or comma-separated. "
+            "Values: agent, human. Default: agent."
+        ),
+    )
+    parser.add_argument(
+        "--tools",
+        dest="tools",
+        action="append",
+        default=None,
+        help=(
+            "Opt-in tool groups. Repeatable or comma-separated. "
+            "Values: contacts, memory. Default: none. "
+            "Note: operators who relied on implicit contacts tools must now "
+            "pass --tools contacts."
+        ),
     )
 
     parser.add_argument(
@@ -131,31 +224,73 @@ Environment Variables:
         help="Port to bind for SSE mode (default: 8000)",
     )
 
-    return parser.parse_args()
+    return parser.parse_args(argv)
+
+
+def _cli_mapping(args: argparse.Namespace) -> dict[str, object]:
+    """Flatten argparse results into the shape `resolve_config` expects."""
+    return {
+        "user_key": args.user_key,
+        "agent_key": args.agent_key,
+        "room_id": args.room_id,
+        "scope": _split_csv(args.scope),
+        "tools": _split_csv(args.tools),
+    }
 
 
 def run() -> None:
     """Run the MCP server with configurable transport mode.
 
-    Supports two transport modes:
-    - STDIO (default): For IDE integration with Cursor, Claude Desktop, etc.
-    - SSE: For remote deployments, Docker containers, or shared team environments.
-
-    Configuration can be set via:
-    1. Command line arguments (highest priority)
-    2. Environment variables
-    3. Default values (lowest priority)
+    Order of operations:
+    1. Parse CLI flags.
+    2. Resolve the Config (dual-credential + scope/tools/room_id).
+    3. Validate; raise ConfigError to exit before FastMCP starts.
+    4. Emit every ConfigWarning entry at WARN level.
+    5. Hand the Config to the lifespan (so AppContext picks it up).
+    6. Register tools (legacy prefix path until Phase 3).
+    7. Start FastMCP.
     """
-    # Determine key type and load appropriate tools
-    key_type = get_key_type(settings.thenvoi_api_key)
-    load_tools(key_type)
-
     args = parse_args()
+
+    config = resolve_config(cli=_cli_mapping(args), env=os.environ)
+
+    # Emit warnings BEFORE validate() — validate might raise and we want the
+    # operator to see "did you mean" hints even if config is also missing
+    # credentials. Order: did-you-mean first, credentials-missing last.
+    for warning in config.warnings:
+        logger.warning(warning.message)
+
+    try:
+        validate(config)
+    except ConfigError as exc:
+        # Fall back to the pure-legacy path: if THENVOI_API_KEY is set and the
+        # operator supplied no explicit scope/keys, honor the old behavior.
+        # This keeps existing deployments booting even when validate() would
+        # otherwise complain. We detect "no new config provided" by checking
+        # that CLI is empty AND no new-style env vars were set.
+        if _is_pure_legacy_invocation(args, config):
+            logger.info(
+                "Proceeding via legacy THENVOI_API_KEY path (no new-style "
+                "credentials or scope supplied)."
+            )
+        else:
+            logger.error("Configuration error: %s", exc)
+            raise SystemExit(2) from exc
+
+    set_pending_config(config)
+
+    # Legacy tool loading — the registrar replaces this in Phase 3.
+    if config.legacy_key and not (config.user_key or config.agent_key):
+        key_type = get_key_type(config.legacy_key)
+    elif config.user_key or config.agent_key:
+        key_type = _choose_legacy_key_type(config)
+    else:
+        key_type = get_key_type(settings.thenvoi_api_key)
+    load_tools(key_type)
 
     # Determine transport mode (CLI args override env vars)
     transport: Literal["stdio", "sse"] = args.transport or settings.transport
 
-    # Update settings for SSE mode if CLI args provided
     if args.host is not None:
         mcp.settings.host = args.host
     if args.port is not None:
@@ -164,6 +299,10 @@ def run() -> None:
     logger.info("Starting thenvoi-mcp-server v%s", __version__)
     logger.info("Base URL: %s", settings.thenvoi_base_url)
     logger.info("API key type: %s", key_type)
+    logger.info("Resolved scope: %s", config.scope or "<none>")
+    logger.info("Resolved tools: %s", config.tools or "<none>")
+    if config.room_id:
+        logger.info("Pinned room id: %s", config.room_id)
 
     if transport == "stdio":
         logger.info("Transport: STDIO (for IDE integration)")
@@ -176,6 +315,38 @@ def run() -> None:
         logger.info("Server ready - listening on http://%s:%s", host, port)
         logger.info("SSE endpoint: /sse | Messages endpoint: /messages/")
         mcp.run(transport="sse")
+
+
+def _is_pure_legacy_invocation(args: argparse.Namespace, config: Config) -> bool:
+    """True when the operator set only THENVOI_API_KEY and no new flags/envs.
+
+    Used to preserve backward compatibility: an operator who never touched the
+    new flags should keep booting even if `validate()` would otherwise fail on
+    the default `--scope agent` with no agent credential, as long as the
+    legacy key is present and can serve something.
+    """
+    if config.legacy_key is None:
+        return False
+    # No new-style CLI flags.
+    if any(
+        getattr(args, attr) is not None
+        for attr in ("user_key", "agent_key", "room_id", "scope", "tools")
+    ):
+        return False
+    # No new-style env vars.
+    new_envs = (
+        "THENVOI_USER_KEY",
+        "THENVOI_AGENT_KEY",
+        "BAND_USER_KEY",
+        "BAND_AGENT_KEY",
+        "THENVOI_MCP_SCOPE",
+        "BAND_MCP_SCOPE",
+        "THENVOI_MCP_TOOLS",
+        "BAND_MCP_TOOLS",
+        "THENVOI_MCP_ROOM_ID",
+        "BAND_MCP_ROOM_ID",
+    )
+    return not any(os.environ.get(name) for name in new_envs)
 
 
 if __name__ == "__main__":

--- a/src/thenvoi_mcp/server.py
+++ b/src/thenvoi_mcp/server.py
@@ -32,6 +32,7 @@ from thenvoi_mcp.shared import (
     mcp,
     set_pending_config,
 )
+from thenvoi_mcp.tools.registrar import register_tools
 
 
 def get_key_type(key: str) -> str:
@@ -301,6 +302,14 @@ def run() -> None:
     else:
         key_type = get_key_type(settings.thenvoi_api_key)
     load_tools(key_type)
+
+    # Phase 3 (INT-351): SDK-driven registrar. Registers every
+    # ``iter_tool_definitions(surface=s, ...)`` entry for each scope in
+    # ``config.scope``. SDK tool names are ``thenvoi_``-prefixed and do not
+    # collide with the legacy handwritten handler names above — both surfaces
+    # coexist during the Phase 3 → Phase 4 transition. Phase 4 (INT-352)
+    # deletes ``load_tools`` and the handwritten handlers.
+    register_tools(mcp, config)
 
     # Determine transport mode (CLI args override env vars)
     transport: Literal["stdio", "sse"] = args.transport or settings.transport

--- a/src/thenvoi_mcp/server.py
+++ b/src/thenvoi_mcp/server.py
@@ -20,6 +20,7 @@ from thenvoi_mcp import __version__
 from thenvoi_mcp.config import (
     Config,
     ConfigError,
+    _legacy_key_capabilities,
     resolve_config,
     settings,
     validate,
@@ -123,17 +124,6 @@ def health_check(ctx: AppContextType) -> str:
         return f"Failed | {key_type} | {e}"
 
 
-def _split_csv(values: list[str] | None) -> list[str] | None:
-    """Expand argparse `append` values so `--scope a,b --scope c` -> ['a','b','c'].
-
-    Returned value is passed to `resolve_config` as-is; `_normalize_list_value`
-    inside `config.py` does the final trim/lowercase/dedupe.
-    """
-    if values is None:
-        return None
-    return list(values)
-
-
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
@@ -228,13 +218,18 @@ Environment Variables:
 
 
 def _cli_mapping(args: argparse.Namespace) -> dict[str, object]:
-    """Flatten argparse results into the shape `resolve_config` expects."""
+    """Flatten argparse results into the shape `resolve_config` expects.
+
+    `scope` and `tools` use argparse `action="append"`, so they arrive as
+    `list[str] | None`. `_normalize_list_value` in `config.py` handles the
+    final trim/split/lowercase/dedupe — we pass the raw list straight through.
+    """
     return {
         "user_key": args.user_key,
         "agent_key": args.agent_key,
         "room_id": args.room_id,
-        "scope": _split_csv(args.scope),
-        "tools": _split_csv(args.tools),
+        "scope": args.scope,
+        "tools": args.tools,
     }
 
 
@@ -276,6 +271,25 @@ def run() -> None:
         else:
             logger.error("Configuration error: %s", exc)
             raise SystemExit(2) from exc
+
+    # Escape-hatch scope write-back (C2/I3): when this is a pure-legacy
+    # invocation, replace the default scope (["agent"]) with whatever the
+    # legacy key actually serves. Two reasons:
+    #   1. Startup logs below print `Resolved scope`; that line must match the
+    #      tools that `load_tools(key_type)` will actually register.
+    #   2. Phase 3's registrar reads `AppContext.scope` to pick the surface.
+    #      A `thnv_u_*` legacy key must land there as ["human"], not ["agent"].
+    # We do this for every pure-legacy invocation (validate() may have passed
+    # for an all-capable `thnv_*` key, in which case config.scope is still the
+    # default ["agent"] but load_tools will load both surfaces).
+    if _is_pure_legacy_invocation(args, config):
+        legacy_human, legacy_agent = _legacy_key_capabilities(config.legacy_key)
+        legacy_scope: list[Literal["agent", "human"]] = []
+        if legacy_agent:
+            legacy_scope.append("agent")
+        if legacy_human:
+            legacy_scope.append("human")
+        config.scope = legacy_scope
 
     set_pending_config(config)
 

--- a/src/thenvoi_mcp/shared.py
+++ b/src/thenvoi_mcp/shared.py
@@ -39,6 +39,7 @@ from thenvoi_rest import AsyncRestClient, RestClient
 from thenvoi_mcp.config import (
     Config,
     ConfigError,
+    _legacy_key_capabilities,
     settings,
     resolve_credential_for_scope,
 )
@@ -128,6 +129,32 @@ def _try_import_agent_tools() -> Any:
     return AgentTools
 
 
+def _choose_legacy_client_credential(
+    config: Config,
+    *,
+    human_cred: str | None,
+    agent_cred: str | None,
+) -> str | None:
+    """Choose the transitional sync-client key for handwritten handlers.
+
+    Scope-specific credentials must beat a stale ``THENVOI_API_KEY`` here just
+    as they do in ``resolve_credential_for_scope``. Otherwise startup can log a
+    human-only scope and register human handlers while the legacy ``RestClient``
+    is still bound to an agent key from ``THENVOI_API_KEY``.
+    """
+    scopes = set(config.scope)
+    if scopes == {"human"}:
+        return human_cred
+    if scopes == {"agent"}:
+        return agent_cred
+
+    legacy_human, legacy_agent = _legacy_key_capabilities(config.legacy_key)
+    if scopes == {"agent", "human"} and legacy_human and legacy_agent:
+        return config.legacy_key
+
+    return human_cred or agent_cred or config.legacy_key
+
+
 def build_app_context(
     config: Config | None = None,
 ) -> AppContext:
@@ -170,11 +197,15 @@ def build_app_context(
 
     # Keep the legacy sync client alive during the transition so the existing
     # `@mcp.tool()` decorated handlers in `tools/agent/*` and `tools/human/*`
-    # continue to work. Prefer the legacy key when set (matches previous
-    # behavior exactly), then fall back to either scope-specific key. Validation
-    # should catch empty credentials before this point; raise loudly here if a
-    # caller bypassed it so the server does not boot into a delayed 401.
-    legacy_for_client = config.legacy_key or human_cred or agent_cred
+    # continue to work. The key must match the resolved scope rather than a
+    # stale legacy env var; validation should catch empty credentials before this
+    # point. Raise loudly here if a caller bypassed it so the server does not
+    # boot into a delayed 401.
+    legacy_for_client = _choose_legacy_client_credential(
+        config,
+        human_cred=human_cred,
+        agent_cred=agent_cred,
+    )
     if legacy_for_client is None:
         raise ConfigError("No API credential available for legacy RestClient")
     client = RestClient(api_key=legacy_for_client, base_url=base_url)

--- a/src/thenvoi_mcp/shared.py
+++ b/src/thenvoi_mcp/shared.py
@@ -27,6 +27,7 @@ import logging
 import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -35,7 +36,12 @@ from mcp.server.session import ServerSession
 from mcp.server.transport_security import TransportSecuritySettings
 from thenvoi_rest import AsyncRestClient, RestClient
 
-from thenvoi_mcp.config import Config, settings, resolve_credential_for_scope
+from thenvoi_mcp.config import (
+    Config,
+    ConfigError,
+    settings,
+    resolve_credential_for_scope,
+)
 
 logging.basicConfig(
     level=logging.INFO,
@@ -59,8 +65,8 @@ class AppContext:
     the current config (e.g. a human-only deployment has no `agent_rest`).
 
     `human_tools` is the startup-constructed singleton returned by
-    `get_human_tools()`. `AgentTools` is constructed per-room and cached in
-    `_agent_tools_cache` by `get_agent_tools()`.
+    `get_human_tools()`. `AgentTools` is constructed per-room and cached in a
+    request-scoped ContextVar by `get_agent_tools()`.
 
     `pinned_room_id`, `scope`, and `tools` carry the resolved Config values
     forward so the registrar (Phase 3) doesn't need to re-resolve.
@@ -81,15 +87,12 @@ class AppContext:
     scope: list[str] = field(default_factory=list)
     tools: list[str] = field(default_factory=list)
 
-    # Per-request cache for AgentTools keyed by room_id. Room-less agent tools
-    # use None as the cache key. The registrar clears this at the start of each
-    # tool call; see `get_agent_tools`.
-    # TODO(INT-351): call reset_agent_tools_cache(ctx) at the start of each
-    # tool invocation. Phase 2 plumbs the cache; Phase 3 owns the reset site.
-    _agent_tools_cache: dict[str | None, Any] = field(default_factory=dict)
-
 
 AppContextType = Context[ServerSession, AppContext, None]
+_agent_tools_cache_var: ContextVar[dict[str | None, Any] | None] = ContextVar(
+    "thenvoi_mcp_agent_tools_cache",
+    default=None,
+)
 
 
 def _try_import_human_tools() -> Any:
@@ -168,13 +171,12 @@ def build_app_context(
     # Keep the legacy sync client alive during the transition so the existing
     # `@mcp.tool()` decorated handlers in `tools/agent/*` and `tools/human/*`
     # continue to work. Prefer the legacy key when set (matches previous
-    # behavior exactly), then fall back to either scope-specific key. If
-    # nothing at all is available, we still construct a client with an empty
-    # key — FastMCP/legacy tool calls will fail at request time with an auth
-    # error rather than at import/lifespan time.
-    legacy_for_client = (
-        config.legacy_key or human_cred or agent_cred or settings.thenvoi_api_key or ""
-    )
+    # behavior exactly), then fall back to either scope-specific key. Validation
+    # should catch empty credentials before this point; raise loudly here if a
+    # caller bypassed it so the server does not boot into a delayed 401.
+    legacy_for_client = config.legacy_key or human_cred or agent_cred
+    if legacy_for_client is None:
+        raise ConfigError("No API credential available for legacy RestClient")
     client = RestClient(api_key=legacy_for_client, base_url=base_url)
 
     # Startup-construct `HumanTools` singleton if the SDK + human client are
@@ -277,7 +279,12 @@ def get_agent_tools(ctx: AppContextType, room_id: str | None) -> Any:
         )
         return None
 
-    cached = app_ctx._agent_tools_cache.get(room_id)
+    cache = _agent_tools_cache_var.get()
+    if cache is None:
+        cache = {}
+        _agent_tools_cache_var.set(cache)
+
+    cached = cache.get(room_id)
     if cached is not None:
         return cached
 
@@ -291,7 +298,7 @@ def get_agent_tools(ctx: AppContextType, room_id: str | None) -> Any:
         logger.warning("Failed to construct AgentTools for room %s: %s", room_id, exc)
         return None
 
-    app_ctx._agent_tools_cache[room_id] = instance
+    cache[room_id] = instance
     return instance
 
 
@@ -300,12 +307,8 @@ def reset_agent_tools_cache(ctx: AppContextType) -> None:
 
     Phase 3's registrar calls this at the start of each tool invocation so the
     cache's per-request semantics hold.
-
-    TODO(INT-351): wire this into the registrar's pre-invocation hook. Phase 2
-    exposes the reset but has no caller; without the Phase 3 wiring the cache
-    will leak across tool calls for the server's lifetime.
     """
-    get_app_context(ctx)._agent_tools_cache.clear()
+    _agent_tools_cache_var.set({})
 
 
 def serialize_response(result: Any, **kwargs: Any) -> str:

--- a/src/thenvoi_mcp/shared.py
+++ b/src/thenvoi_mcp/shared.py
@@ -69,6 +69,8 @@ class AppContext:
     # Legacy single-client path (kept for existing handwritten tools; removed
     # in Phase 4). Always populated so the existing `@mcp.tool()` handlers
     # that do `get_app_context(ctx).client.<something>` keep type-checking.
+    # TODO(INT-352): delete AppContext.client once handwritten tools under
+    # tools/agent/* and tools/human/* are removed.
     client: RestClient
 
     # Phase 2 additions.
@@ -81,6 +83,8 @@ class AppContext:
 
     # Per-request cache for AgentTools keyed by room_id. The registrar clears
     # this at the start of each tool call; see `get_agent_tools`.
+    # TODO(INT-351): call reset_agent_tools_cache(ctx) at the start of each
+    # tool invocation. Phase 2 plumbs the cache; Phase 3 owns the reset site.
     _agent_tools_cache: dict[str, Any] = field(default_factory=dict)
 
 
@@ -294,6 +298,10 @@ def reset_agent_tools_cache(ctx: AppContextType) -> None:
 
     Phase 3's registrar calls this at the start of each tool invocation so the
     cache's per-request semantics hold.
+
+    TODO(INT-351): wire this into the registrar's pre-invocation hook. Phase 2
+    exposes the reset but has no caller; without the Phase 3 wiring the cache
+    will leak across tool calls for the server's lifetime.
     """
     get_app_context(ctx)._agent_tools_cache.clear()
 

--- a/src/thenvoi_mcp/shared.py
+++ b/src/thenvoi_mcp/shared.py
@@ -81,11 +81,12 @@ class AppContext:
     scope: list[str] = field(default_factory=list)
     tools: list[str] = field(default_factory=list)
 
-    # Per-request cache for AgentTools keyed by room_id. The registrar clears
-    # this at the start of each tool call; see `get_agent_tools`.
+    # Per-request cache for AgentTools keyed by room_id. Room-less agent tools
+    # use None as the cache key. The registrar clears this at the start of each
+    # tool call; see `get_agent_tools`.
     # TODO(INT-351): call reset_agent_tools_cache(ctx) at the start of each
     # tool invocation. Phase 2 plumbs the cache; Phase 3 owns the reset site.
-    _agent_tools_cache: dict[str, Any] = field(default_factory=dict)
+    _agent_tools_cache: dict[str | None, Any] = field(default_factory=dict)
 
 
 AppContextType = Context[ServerSession, AppContext, None]
@@ -255,14 +256,15 @@ def get_human_tools(ctx: AppContextType) -> Any:
     return app_ctx.human_tools
 
 
-def get_agent_tools(ctx: AppContextType, room_id: str) -> Any:
+def get_agent_tools(ctx: AppContextType, room_id: str | None) -> Any:
     """Return an `AgentTools` instance scoped to `room_id`.
 
     Per-request cache: Phase 3 can call this multiple times in the same tool
     invocation (participant-resolution paths walk back to the room) and must
     not construct twice. The registrar is responsible for clearing the cache
     at the start of each request; within a single call, repeated
-    `get_agent_tools(ctx, "r1")` returns the same object.
+    `get_agent_tools(ctx, "r1")` returns the same object. Room-less agent tools
+    pass None through to AgentTools.
 
     Returns None when the SDK isn't installed or when no agent credential is
     configured.

--- a/src/thenvoi_mcp/shared.py
+++ b/src/thenvoi_mcp/shared.py
@@ -1,17 +1,41 @@
+"""Shared app context, logger, and FastMCP singleton for thenvoi-mcp.
+
+Phase 2 (INT-350) extends `AppContext` with dual REST clients:
+`human_rest` (bound to `user_key` or a human-capable legacy key) and
+`agent_rest` (bound to `agent_key` or an agent-capable legacy key). The
+single `client` attribute is retained during the transition so the
+currently-handwritten tools in `tools/agent/` and `tools/human/` keep
+working; Phase 4 (INT-352) deletes those and `client` goes with them.
+
+HumanTools / AgentTools coordination with INT-349
+-------------------------------------------------
+The SDK's `HumanTools` class lands in Phase 1 (INT-349) in `thenvoi-sdk-python`
+and is not yet available in this environment (the repo depends on
+`thenvoi-client-rest`, which is the Fern-generated REST client only).
+`get_human_tools()` / `get_agent_tools()` import `HumanTools` / `AgentTools`
+lazily and guard the import: if either import fails, the helper logs a WARN
+and returns `None`. Phase 3 (INT-351) is responsible for the registrar that
+calls these helpers; until INT-349 is merged and the SDK is installed, the
+helpers will fail closed with a structured log line rather than an import-time
+crash. This keeps Phase 2 mergeable without waiting for Phase 1.
+"""
+
+from __future__ import annotations
+
 import json
 import logging
 import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.server.transport_security import TransportSecuritySettings
-from thenvoi_rest import RestClient
+from thenvoi_rest import AsyncRestClient, RestClient
 
-from thenvoi_mcp.config import settings
+from thenvoi_mcp.config import Config, settings, resolve_credential_for_scope
 
 logging.basicConfig(
     level=logging.INFO,
@@ -23,24 +47,171 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class AppContext:
-    """Type-safe container for application dependencies."""
+    """Type-safe container for application dependencies.
 
+    `client` is the legacy single sync `RestClient` used by the handwritten
+    `tools/agent/*` and `tools/human/*` handlers. It is always populated
+    during the transition and goes away in Phase 4 (INT-352) once those
+    handlers are deleted.
+
+    `human_rest` / `agent_rest` are the new async clients used by Phase 3's
+    registrar. They may be None when the corresponding scope is not served by
+    the current config (e.g. a human-only deployment has no `agent_rest`).
+
+    `human_tools` is the startup-constructed singleton returned by
+    `get_human_tools()`. `AgentTools` is constructed per-room and cached in
+    `_agent_tools_cache` by `get_agent_tools()`.
+
+    `pinned_room_id`, `scope`, and `tools` carry the resolved Config values
+    forward so the registrar (Phase 3) doesn't need to re-resolve.
+    """
+
+    # Legacy single-client path (kept for existing handwritten tools; removed
+    # in Phase 4). Always populated so the existing `@mcp.tool()` handlers
+    # that do `get_app_context(ctx).client.<something>` keep type-checking.
     client: RestClient
+
+    # Phase 2 additions.
+    human_rest: AsyncRestClient | None = None
+    agent_rest: AsyncRestClient | None = None
+    human_tools: Any = None  # HumanTools | None; typed Any to avoid SDK hard-dep
+    pinned_room_id: str | None = None
+    scope: list[str] = field(default_factory=list)
+    tools: list[str] = field(default_factory=list)
+
+    # Per-request cache for AgentTools keyed by room_id. The registrar clears
+    # this at the start of each tool call; see `get_agent_tools`.
+    _agent_tools_cache: dict[str, Any] = field(default_factory=dict)
 
 
 AppContextType = Context[ServerSession, AppContext, None]
+
+
+def _try_import_human_tools() -> Any:
+    """Return SDK `HumanTools` class or None if unavailable.
+
+    Guarded to tolerate the Phase 1 (INT-349) SDK landing on a different
+    timeline. When Phase 3 runs and the SDK is installed, this resolves; until
+    then, the registrar sees None and the helper logs a structured warning.
+    """
+    try:
+        from thenvoi.runtime.tools import HumanTools  # type: ignore[import-not-found]
+    except Exception as exc:  # pragma: no cover - import-time guard
+        logger.warning(
+            "HumanTools unavailable (SDK not installed or INT-349 not yet "
+            "merged); human tools will not be constructed: %s",
+            exc,
+        )
+        return None
+    return HumanTools
+
+
+def _try_import_agent_tools() -> Any:
+    """Return SDK `AgentTools` class or None if unavailable."""
+    try:
+        from thenvoi.runtime.tools import AgentTools  # type: ignore[import-not-found]
+    except Exception as exc:  # pragma: no cover - import-time guard
+        logger.warning(
+            "AgentTools unavailable (SDK not installed); agent tools will not "
+            "be constructed: %s",
+            exc,
+        )
+        return None
+    return AgentTools
+
+
+def build_app_context(
+    config: Config | None = None,
+) -> AppContext:
+    """Construct an `AppContext` from a resolved `Config`.
+
+    Per-scope `AsyncRestClient` instances are built lazily: a client is only
+    constructed for a scope that resolves to a credential. This keeps
+    human-only or agent-only deployments from opening connections they'll
+    never use.
+
+    If `config` is None, we fall back to the legacy `THENVOI_API_KEY` path:
+    the sync `client` is populated from `settings.thenvoi_api_key` and the
+    new async slots stay None. This preserves current behavior for any caller
+    that has not yet moved to `resolve_config(...)`.
+
+    `AppContext.client` is always populated during the Phase 2 transition.
+    Phase 4 (INT-352) removes the legacy `client` slot once handwritten tool
+    handlers are deleted.
+    """
+    base_url = settings.thenvoi_base_url
+
+    if config is None:
+        # Legacy path: single sync client, no new slots.
+        client = RestClient(
+            api_key=settings.thenvoi_api_key,
+            base_url=base_url,
+        )
+        return AppContext(client=client)
+
+    human_rest: AsyncRestClient | None = None
+    agent_rest: AsyncRestClient | None = None
+
+    human_cred = resolve_credential_for_scope(config, "human")
+    agent_cred = resolve_credential_for_scope(config, "agent")
+
+    if human_cred is not None:
+        human_rest = AsyncRestClient(api_key=human_cred, base_url=base_url)
+    if agent_cred is not None:
+        agent_rest = AsyncRestClient(api_key=agent_cred, base_url=base_url)
+
+    # Keep the legacy sync client alive during the transition so the existing
+    # `@mcp.tool()` decorated handlers in `tools/agent/*` and `tools/human/*`
+    # continue to work. Prefer the legacy key when set (matches previous
+    # behavior exactly), then fall back to either scope-specific key. If
+    # nothing at all is available, we still construct a client with an empty
+    # key — FastMCP/legacy tool calls will fail at request time with an auth
+    # error rather than at import/lifespan time.
+    legacy_for_client = (
+        config.legacy_key or human_cred or agent_cred or settings.thenvoi_api_key or ""
+    )
+    client = RestClient(api_key=legacy_for_client, base_url=base_url)
+
+    # Startup-construct `HumanTools` singleton if the SDK + human client are
+    # both available. AgentTools is per-room and constructed on demand.
+    human_tools_obj: Any = None
+    HumanToolsCls = _try_import_human_tools()
+    if HumanToolsCls is not None and human_rest is not None:
+        try:
+            human_tools_obj = HumanToolsCls(rest=human_rest)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Failed to construct HumanTools singleton: %s", exc)
+            human_tools_obj = None
+
+    return AppContext(
+        client=client,
+        human_rest=human_rest,
+        agent_rest=agent_rest,
+        human_tools=human_tools_obj,
+        pinned_room_id=config.room_id,
+        scope=list(config.scope),
+        tools=list(config.tools),
+    )
+
+
+# Module-level slot the lifespan reads; server.run() populates this before
+# starting FastMCP. Using a module-level value (vs passing through closures)
+# matches how `settings` is already consumed and keeps the lifespan signature
+# unchanged.
+_pending_config: Config | None = None
+
+
+def set_pending_config(config: Config) -> None:
+    """Store the resolved config for the lifespan to pick up at startup."""
+    global _pending_config
+    _pending_config = config
 
 
 @asynccontextmanager
 async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
     """Lifespan context manager for MCP server."""
     logger.info("Initializing Thenvoi API client")
-    client = RestClient(
-        api_key=settings.thenvoi_api_key,
-        base_url=settings.thenvoi_base_url,
-    )
-
-    app_context = AppContext(client=client)
+    app_context = build_app_context(_pending_config)
     logger.info("Thenvoi MCP server lifespan started successfully")
 
     try:
@@ -54,9 +225,77 @@ def get_app_context(ctx: AppContextType) -> AppContext:
 
     Usage in tools:
         app_ctx = get_app_context(ctx)
-        client = app_ctx.client
+        client = app_ctx.client          # legacy sync path
+        human_rest = app_ctx.human_rest  # new async path (Phase 3)
     """
     return ctx.request_context.lifespan_context
+
+
+def get_human_tools(ctx: AppContextType) -> Any:
+    """Return the startup-constructed `HumanTools` singleton, or None.
+
+    Phase 3 (INT-351) calls this per tool invocation. The singleton is built
+    once in `build_app_context` from the human `AsyncRestClient`; there is no
+    per-request reconstruction.
+
+    Returns None when the SDK isn't installed (INT-349 not yet merged) or when
+    the deployment has no human credential. The caller is responsible for
+    surfacing that as an actionable error.
+    """
+    app_ctx = get_app_context(ctx)
+    if app_ctx.human_tools is None:
+        logger.warning(
+            "get_human_tools(): HumanTools not available. Ensure the Thenvoi "
+            "SDK (INT-349) is installed and a human credential is configured."
+        )
+    return app_ctx.human_tools
+
+
+def get_agent_tools(ctx: AppContextType, room_id: str) -> Any:
+    """Return an `AgentTools` instance scoped to `room_id`.
+
+    Per-request cache: Phase 3 can call this multiple times in the same tool
+    invocation (participant-resolution paths walk back to the room) and must
+    not construct twice. The registrar is responsible for clearing the cache
+    at the start of each request; within a single call, repeated
+    `get_agent_tools(ctx, "r1")` returns the same object.
+
+    Returns None when the SDK isn't installed or when no agent credential is
+    configured.
+    """
+    app_ctx = get_app_context(ctx)
+    if app_ctx.agent_rest is None:
+        logger.warning(
+            "get_agent_tools(room_id=%s): no agent credential configured.",
+            room_id,
+        )
+        return None
+
+    cached = app_ctx._agent_tools_cache.get(room_id)
+    if cached is not None:
+        return cached
+
+    AgentToolsCls = _try_import_agent_tools()
+    if AgentToolsCls is None:
+        return None
+
+    try:
+        instance = AgentToolsCls(room_id=room_id, rest=app_ctx.agent_rest)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Failed to construct AgentTools for room %s: %s", room_id, exc)
+        return None
+
+    app_ctx._agent_tools_cache[room_id] = instance
+    return instance
+
+
+def reset_agent_tools_cache(ctx: AppContextType) -> None:
+    """Clear the per-request `AgentTools` cache.
+
+    Phase 3's registrar calls this at the start of each tool invocation so the
+    cache's per-request semantics hold.
+    """
+    get_app_context(ctx)._agent_tools_cache.clear()
 
 
 def serialize_response(result: Any, **kwargs: Any) -> str:

--- a/src/thenvoi_mcp/tools/registrar.py
+++ b/src/thenvoi_mcp/tools/registrar.py
@@ -1,0 +1,473 @@
+"""SDK-driven MCP tool registrar (Phase 3 of INT-338, INT-351).
+
+Replaces the handwritten per-tool ``@mcp.tool()`` registrations with a
+scope-filtered loop over ``thenvoi.runtime.tools.iter_tool_definitions(...)``.
+Each handler is a closure that:
+
+1. Resets the per-request AgentTools cache on ``AppContext``.
+2. Resolves the room id from validated input (or injects ``pinned_room_id``).
+3. Dispatches to the Phase-1 ``HumanTools`` / ``AgentTools`` SDK method.
+
+Design deviation from the Phase 3 spec (resolved with the ticket author)
+-----------------------------------------------------------------------
+The spec originally told the registrar to classify agent tools by checking
+for a ``room_id`` field on ``ToolDefinition.input_model.model_fields``. That
+classifier does not work for agent tools, because ``AgentTools`` is *room-
+scoped via its constructor* (``AgentTools(room_id=..., rest=...)``) — the
+SDK input models only cover method arguments, not the construction-time
+room id. Putting ``room_id`` on the SDK input model would create a mismatch
+between the input schema and the underlying ``AgentTools`` method
+signature.
+
+Resolution: the registrar *itself* is the layer that adds a room field to
+the advertised agent tool schema. Today's handwritten MCP handlers use
+``chat_id`` on every room-bound agent tool (see
+``tools/agent/agent_messages.py`` and friends) — keeping that name means
+zero breaking change for existing MCP consumers. ``AliasChoices("chat_id",
+"room_id")`` makes the forward-compat ``room_id`` name work too, matching
+the Phase 3 spec's intent. See ``AGENT_ROOM_BOUND_TOOL_NAMES`` below.
+
+Human-surface classification is unchanged: human input models already carry
+a ``chat_id`` field where applicable (Phase 1 derived them from
+``HumanTools`` method signatures), so the Phase 3 spec's
+``model_fields``-based classifier works for the human surface.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from typing import Annotated, Any, Callable
+
+from mcp.server.fastmcp import FastMCP
+from pydantic import AliasChoices, BaseModel, Field, ValidationError, create_model
+from pydantic.fields import FieldInfo
+from pydantic.json_schema import SkipJsonSchema
+
+from thenvoi_mcp.config import Config
+from thenvoi_mcp.shared import (
+    AppContextType,
+    get_agent_tools,
+    get_human_tools,
+    logger,
+    reset_agent_tools_cache,
+)
+
+# ---------------------------------------------------------------------------
+# Agent room-bound tools
+# ---------------------------------------------------------------------------
+#
+# These are the agent tools whose *current* MCP handler in
+# ``src/thenvoi_mcp/tools/agent/*.py`` takes ``chat_id`` as a kwarg (i.e. the
+# handler is room-scoped). Because ``AgentTools`` is constructor-scoped, the
+# Phase 1 SDK input models do not carry a room field — so the registrar has
+# to re-add it at the transport layer.
+#
+# Derived by grepping today's agent handlers for ``chat_id``. Kept as a
+# module-level constant so tests can assert on it and so Phase 4 (INT-352)
+# has an obvious pivot point for the handwritten-handler deletion.
+AGENT_ROOM_BOUND_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "thenvoi_send_message",
+        "thenvoi_send_event",
+        "thenvoi_add_participant",
+        "thenvoi_remove_participant",
+        "thenvoi_get_participants",
+        "thenvoi_lookup_peers",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Input-model transformers
+# ---------------------------------------------------------------------------
+
+
+def _extend_with_chat_id(
+    original: type[BaseModel],
+    pinned_room_id: str | None,
+) -> type[BaseModel]:
+    """Return a subclass of ``original`` that ADDS a ``chat_id`` field.
+
+    Applied to agent room-bound tools (the SDK input models do not carry a
+    room field; see module docstring).
+
+    - Unpinned: ``chat_id`` is a required ``str`` with
+      ``validation_alias=AliasChoices("chat_id", "room_id")`` so callers can
+      post either name.
+    - Pinned: ``chat_id`` is ``SkipJsonSchema[str | None]`` defaulted to
+      ``None`` — the field is hidden from the advertised JSON schema but
+      still accepted by the validator if a client sends it. The handler
+      injects ``pinned_room_id`` at call time.
+    """
+    if pinned_room_id is None:
+        return create_model(  # type: ignore[call-overload]
+            f"{original.__name__}WithChatId",
+            __base__=original,
+            chat_id=(
+                str,
+                Field(
+                    ...,
+                    validation_alias=AliasChoices("chat_id", "room_id"),
+                    description=(
+                        "ID of the chat room (accepted as 'chat_id' or 'room_id')."
+                    ),
+                ),
+            ),
+        )
+    return create_model(  # type: ignore[call-overload]
+        f"{original.__name__}WithChatIdPinned",
+        __base__=original,
+        chat_id=(
+            SkipJsonSchema[str | None],
+            Field(
+                default=None,
+                validation_alias=AliasChoices("chat_id", "room_id"),
+                description=("Pinned room id (hidden from advertised schema)."),
+            ),
+        ),
+    )
+
+
+def _pin_existing_chat_id(
+    original: type[BaseModel],
+    pinned_room_id: str,  # noqa: ARG001 - injected at call time, not in model
+) -> type[BaseModel]:
+    """Return a subclass that re-annotates existing ``chat_id`` as pinned.
+
+    Applied to human room-bound tools (the SDK input models already have
+    ``chat_id``). The advertised schema omits the field; inbound values are
+    still accepted via alias so an older client passing ``chat_id`` does not
+    fail validation. The handler injects ``pinned_room_id`` at call time.
+    """
+    return create_model(  # type: ignore[call-overload]
+        f"{original.__name__}Pinned",
+        __base__=original,
+        chat_id=(
+            SkipJsonSchema[str | None],
+            Field(
+                default=None,
+                validation_alias=AliasChoices("chat_id", "room_id"),
+                description=("Pinned room id (hidden from advertised schema)."),
+            ),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Handler construction
+# ---------------------------------------------------------------------------
+
+
+def _build_handler_signature(
+    ctx_param_name: str,
+    input_model: type[BaseModel],
+) -> inspect.Signature:
+    """Build a ``inspect.Signature`` for the dynamic handler.
+
+    FastMCP inspects the handler's signature to derive the advertised JSON
+    schema (see ``fastmcp.utilities.func_metadata.func_metadata``). We
+    therefore need a real signature with one parameter per
+    ``input_model`` field (plus the ``Context`` parameter FastMCP auto-
+    injects).
+
+    Fields annotated as ``SkipJsonSchema[...]`` are intentionally omitted:
+    they are pinned-mode fields whose value is injected at call time and
+    MUST NOT appear in the advertised schema.
+
+    ``validation_alias`` (e.g. ``AliasChoices("chat_id", "room_id")``) is
+    propagated onto the parameter annotation so FastMCP's internally-
+    generated arg model accepts alternate names at the wire.
+    """
+    ctx_param = inspect.Parameter(
+        ctx_param_name,
+        kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        annotation=AppContextType,
+    )
+
+    parameters: list[inspect.Parameter] = [ctx_param]
+    for field_name, field_info in input_model.model_fields.items():
+        if _is_skip_json_schema(field_info):
+            continue
+        base_ann = field_info.annotation if field_info.annotation is not None else Any
+
+        # Copy ``validation_alias`` onto the synthesized parameter so
+        # FastMCP's derived arg model accepts both chat_id and room_id.
+        field_kwargs: dict[str, Any] = {}
+        if field_info.validation_alias is not None:
+            field_kwargs["validation_alias"] = field_info.validation_alias
+        if field_info.description:
+            field_kwargs["description"] = field_info.description
+
+        annotation = base_ann
+        if field_kwargs:
+            annotation = Annotated[base_ann, Field(**field_kwargs)]
+
+        if field_info.is_required():
+            parameters.append(
+                inspect.Parameter(
+                    field_name,
+                    kind=inspect.Parameter.KEYWORD_ONLY,
+                    annotation=annotation,
+                )
+            )
+        else:
+            default = field_info.default
+            parameters.append(
+                inspect.Parameter(
+                    field_name,
+                    kind=inspect.Parameter.KEYWORD_ONLY,
+                    annotation=annotation,
+                    default=default,
+                )
+            )
+
+    return inspect.Signature(parameters=parameters, return_annotation=str)
+
+
+def _is_skip_json_schema(field_info: FieldInfo) -> bool:
+    """Return True if ``field_info.annotation`` is ``SkipJsonSchema[...]``."""
+    metadata = getattr(field_info, "metadata", None) or []
+    for meta in metadata:
+        if meta.__class__.__name__ == "SkipJsonSchema":
+            return True
+    # Fallback: also inspect the annotation repr for the SkipJsonSchema marker
+    # (older pydantic versions store it differently).
+    ann_repr = repr(field_info.annotation)
+    return "SkipJsonSchema" in ann_repr
+
+
+def _serialize(result: Any) -> str:
+    """Serialize SDK method output to a JSON string for MCP wire transport."""
+    if result is None:
+        return json.dumps(None)
+    if isinstance(result, str):
+        return result
+    if hasattr(result, "model_dump"):
+        return json.dumps(result.model_dump(mode="json"), default=str, indent=2)
+    if isinstance(result, list):
+        out = []
+        for item in result:
+            if hasattr(item, "model_dump"):
+                out.append(item.model_dump(mode="json"))
+            else:
+                out.append(item)
+        return json.dumps(out, default=str, indent=2)
+    return json.dumps(result, default=str, indent=2)
+
+
+async def _invoke(
+    *,
+    surface: str,
+    tool_name: str,
+    method_name: str,
+    input_model: type[BaseModel],
+    pinned_room_id: str | None,
+    is_agent_room_bound: bool,
+    is_human_room_bound: bool,
+    ctx: AppContextType,
+    kwargs: dict[str, Any],
+) -> str:
+    """The actual async dispatch body shared by every generated handler."""
+    reset_agent_tools_cache(ctx)
+
+    # Inject pinned room id BEFORE validation so the input model's chat_id
+    # field is populated from the pin even though it is hidden from the
+    # advertised schema.
+    if pinned_room_id is not None and (is_agent_room_bound or is_human_room_bound):
+        kwargs["chat_id"] = pinned_room_id
+
+    try:
+        validated = input_model.model_validate(kwargs)
+    except ValidationError as exc:
+        errors = "; ".join(
+            f"{err['loc'][0]}: {err['msg']}" for err in exc.errors()
+        )
+        raise ValueError(f"Invalid arguments for {tool_name}: {errors}") from exc
+
+    call_kwargs = validated.model_dump(exclude_none=True, by_alias=False)
+
+    if surface == "agent":
+        # Agent tools: pull chat_id out of kwargs and scope AgentTools to it.
+        if is_agent_room_bound:
+            chat_id = call_kwargs.pop("chat_id", None)
+            if not chat_id:
+                raise ValueError(
+                    f"{tool_name}: missing chat_id (or room_id) for room-bound tool"
+                )
+            tools_instance = get_agent_tools(ctx, chat_id)
+        else:
+            tools_instance = get_agent_tools(ctx, pinned_room_id)
+    else:
+        tools_instance = get_human_tools(ctx)
+
+    if tools_instance is None:
+        raise ValueError(
+            f"{tool_name}: {surface} tools not available (SDK not installed or "
+            "no credential configured for this scope)"
+        )
+
+    method = getattr(tools_instance, method_name, None)
+    if method is None or not callable(method):
+        raise RuntimeError(
+            f"{tool_name}: method '{method_name}' not found on "
+            f"{type(tools_instance).__name__}"
+        )
+
+    result = method(**call_kwargs)
+    if inspect.isawaitable(result):
+        result = await result
+
+    return _serialize(result)
+
+
+def make_handler(
+    *,
+    tool_name: str,
+    surface: str,
+    method_name: str,
+    input_model: type[BaseModel],
+    pinned_room_id: str | None,
+    is_agent_room_bound: bool,
+    is_human_room_bound: bool,
+) -> Callable[..., Any]:
+    """Return a dynamically-signatured async handler for ``mcp.add_tool``.
+
+    FastMCP inspects ``__signature__`` / real parameters to build the tool's
+    advertised JSON schema. We therefore synthesize a function whose
+    parameter list matches the (post-extension, post-pin) input model's
+    visible fields.
+    """
+    ctx_param_name = "ctx"
+
+    async def _dispatch(**kwargs: Any) -> str:
+        ctx = kwargs.pop(ctx_param_name)
+        return await _invoke(
+            surface=surface,
+            tool_name=tool_name,
+            method_name=method_name,
+            input_model=input_model,
+            pinned_room_id=pinned_room_id,
+            is_agent_room_bound=is_agent_room_bound,
+            is_human_room_bound=is_human_room_bound,
+            ctx=ctx,
+            kwargs=kwargs,
+        )
+
+    sig = _build_handler_signature(ctx_param_name, input_model)
+    _dispatch.__signature__ = sig  # type: ignore[attr-defined]
+    _dispatch.__name__ = tool_name
+    # Description comes from the SDK input model's docstring (Phase 1 sets
+    # these to the LLM-facing tool description).
+    _dispatch.__doc__ = (input_model.__doc__ or "").strip() or f"Execute {tool_name}"
+
+    # Build an Annotated annotation map for FastMCP's get_type_hints() call.
+    # We can't rely on forward-referenced types since the model is dynamic,
+    # so we stamp __annotations__ directly.
+    annotations: dict[str, Any] = {ctx_param_name: AppContextType}
+    for param in sig.parameters.values():
+        if param.name == ctx_param_name:
+            continue
+        annotations[param.name] = param.annotation
+    annotations["return"] = str
+    _dispatch.__annotations__ = annotations
+
+    return _dispatch
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def _classify_tool(
+    definition: Any,  # ToolDefinition
+) -> tuple[bool, bool]:
+    """Return (is_agent_room_bound, is_human_room_bound) for a definition.
+
+    Agent tools use the hard-coded ``AGENT_ROOM_BOUND_TOOL_NAMES`` set
+    because the SDK input models don't carry a room field (see module
+    docstring).
+
+    Human tools are classified by inspecting ``input_model.model_fields``
+    for ``chat_id`` — the Phase 1 human models carry it where applicable.
+    """
+    if definition.surface == "agent":
+        return (definition.name in AGENT_ROOM_BOUND_TOOL_NAMES, False)
+    if definition.surface == "human":
+        has_chat_id = "chat_id" in definition.input_model.model_fields
+        return (False, has_chat_id)
+    return (False, False)
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+
+def register_tools(mcp: FastMCP, config: Config) -> None:
+    """Register every SDK-defined tool for the scopes in ``config.scope``.
+
+    Delegates to ``iter_tool_definitions(surface=..., include_contacts=...,
+    include_memory=...)`` for the source of truth on which tools are
+    available, and translates each ``ToolDefinition`` into a FastMCP tool
+    registration with an appropriate input schema (extended with chat_id
+    for agent room-bound tools, schema-hidden pinned for pinned-mode
+    room-bound tools on either surface).
+
+    Safe to call after the handwritten ``tools.agent.*`` / ``tools.human.*``
+    modules have been imported: SDK tool names are ``thenvoi_``-prefixed
+    and do not collide with the legacy handwritten handler names.
+    """
+    try:
+        from thenvoi.runtime.tools import iter_tool_definitions
+    except Exception as exc:  # pragma: no cover - import-time guard
+        logger.warning(
+            "register_tools(): Thenvoi SDK not available — skipping SDK-driven "
+            "tool registration. Legacy handwritten handlers will still serve "
+            "traffic. (%s)",
+            exc,
+        )
+        return
+
+    include_contacts = "contacts" in config.tools
+    include_memory = "memory" in config.tools
+    pinned_room_id = config.room_id
+
+    total = 0
+    for surface in config.scope:
+        definitions = iter_tool_definitions(
+            surface=surface,
+            include_contacts=include_contacts,
+            include_memory=include_memory,
+        )
+        for definition in definitions:
+            is_agent_room_bound, is_human_room_bound = _classify_tool(definition)
+
+            # Build the per-tool input model (original, extended, or pinned).
+            model: type[BaseModel] = definition.input_model
+            if is_agent_room_bound:
+                model = _extend_with_chat_id(model, pinned_room_id)
+            elif is_human_room_bound and pinned_room_id is not None:
+                model = _pin_existing_chat_id(model, pinned_room_id)
+
+            handler = make_handler(
+                tool_name=definition.name,
+                surface=definition.surface,
+                method_name=definition.method_name,
+                input_model=model,
+                pinned_room_id=pinned_room_id,
+                is_agent_room_bound=is_agent_room_bound,
+                is_human_room_bound=is_human_room_bound,
+            )
+            mcp.add_tool(handler, name=definition.name)
+            total += 1
+
+    logger.info("SDK-driven registrar: registered %d tools", total)
+
+
+__all__ = [
+    "AGENT_ROOM_BOUND_TOOL_NAMES",
+    "make_handler",
+    "register_tools",
+]

--- a/src/thenvoi_mcp/tools/registrar.py
+++ b/src/thenvoi_mcp/tools/registrar.py
@@ -280,9 +280,7 @@ async def _invoke(
     try:
         validated = input_model.model_validate(kwargs)
     except ValidationError as exc:
-        errors = "; ".join(
-            f"{err['loc'][0]}: {err['msg']}" for err in exc.errors()
-        )
+        errors = "; ".join(f"{err['loc'][0]}: {err['msg']}" for err in exc.errors())
         raise ValueError(f"Invalid arguments for {tool_name}: {errors}") from exc
 
     call_kwargs = validated.model_dump(exclude_none=True, by_alias=False)
@@ -420,7 +418,7 @@ def register_tools(mcp: FastMCP, config: Config) -> None:
     and do not collide with the legacy handwritten handler names.
     """
     try:
-        from thenvoi.runtime.tools import iter_tool_definitions
+        from thenvoi.runtime.tools import iter_tool_definitions  # type: ignore[import-not-found]
     except Exception as exc:  # pragma: no cover - import-time guard
         logger.warning(
             "register_tools(): Thenvoi SDK not available — skipping SDK-driven "

--- a/src/thenvoi_mcp/tools/registrar.py
+++ b/src/thenvoi_mcp/tools/registrar.py
@@ -432,12 +432,16 @@ def register_tools(mcp: FastMCP, config: Config) -> None:
     include_memory = "memory" in config.tools
     pinned_room_id = config.room_id
 
+    iter_definitions: Any = iter_tool_definitions
+
     total = 0
     for surface in config.scope:
-        definitions = iter_tool_definitions(
-            surface=surface,
-            include_contacts=include_contacts,
-            include_memory=include_memory,
+        definitions: list[Any] = list(
+            iter_definitions(
+                surface=surface,
+                include_contacts=include_contacts,
+                include_memory=include_memory,
+            )
         )
         for definition in definitions:
             is_agent_room_bound, is_human_room_bound = _classify_tool(definition)

--- a/tests/integration/test_forwarding.py
+++ b/tests/integration/test_forwarding.py
@@ -1,0 +1,295 @@
+"""Integration tests for the SDK-driven MCP registrar (INT-351, Phase 3).
+
+Covers the acceptance criteria enumerated in INT-351: CLI flag combinations
+(``--scope``, ``--tools``, ``--room-id``) produce the expected advertised
+tool surface and the expected dispatch behavior when a tool is called.
+
+Drives the FastMCP server in-process via ``mcp._tool_manager.call_tool`` to
+exercise the full registration + validation + dispatch path without
+requiring an actual stdio subprocess. This is deliberate: today's
+integration suite already spawns subprocesses via ``@requires_api``, but
+those tests hit a live API. Phase 3 needs to verify the transport wiring
+itself, which a live server can't distinguish from legacy handlers. A
+lightweight in-process test gives us that signal, and the existing
+``@requires_api`` smoke tests catch remaining live-API regressions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from thenvoi_mcp.config import Config
+from thenvoi_mcp.tools import registrar
+from thenvoi_mcp.tools.registrar import register_tools
+
+
+@dataclass
+class _FakeAppCtx:
+    """Stand-in for ``AppContext`` for in-process dispatch tests."""
+
+    human_tools: Any = None
+    agent_tools_by_room: dict[str, Any] | None = None
+    _cache_reset_count: int = 0
+
+    def __post_init__(self) -> None:
+        if self.agent_tools_by_room is None:
+            self.agent_tools_by_room = {}
+
+
+class _FakeCtx:
+    """Stand-in for ``AppContextType`` (the FastMCP Context wrapper)."""
+
+    def __init__(self, app_ctx: _FakeAppCtx) -> None:
+        self.request_context = MagicMock()
+        self.request_context.lifespan_context = app_ctx
+
+
+@pytest.fixture(autouse=True)
+def _patch_tool_resolvers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect ``get_*_tools`` / cache reset to the ``_FakeAppCtx`` payload.
+
+    We can't use a real ``AppContext`` here because that would require a
+    live REST client. The fake app ctx holds pre-built MagicMock instances.
+    """
+
+    def fake_get_human_tools(ctx: Any) -> Any:
+        app = ctx.request_context.lifespan_context
+        return app.human_tools
+
+    def fake_get_agent_tools(ctx: Any, room_id: str) -> Any:
+        app = ctx.request_context.lifespan_context
+        return app.agent_tools_by_room.get(room_id) or app.agent_tools_by_room.get("*")
+
+    def fake_reset(ctx: Any) -> None:
+        app = ctx.request_context.lifespan_context
+        app._cache_reset_count += 1
+
+    monkeypatch.setattr(registrar, "get_human_tools", fake_get_human_tools)
+    monkeypatch.setattr(registrar, "get_agent_tools", fake_get_agent_tools)
+    monkeypatch.setattr(registrar, "reset_agent_tools_cache", fake_reset)
+
+
+# ---------------------------------------------------------------------------
+# --scope agent,human (no --tools, no --room-id)
+# ---------------------------------------------------------------------------
+
+
+async def test_scope_agent_human_no_tools_registers_both_surfaces_without_contacts() -> (
+    None
+):
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["agent", "human"],
+        tools=[],
+        agent_key="a",
+        user_key="u",
+    )
+    register_tools(mcp, cfg)
+
+    names = {t.name for t in await mcp.list_tools()}
+    # Agent surface present
+    assert "thenvoi_send_message" in names
+    # Human surface present
+    assert "thenvoi_send_my_chat_message" in names
+    # Contacts not present by default
+    assert "thenvoi_list_my_contacts" not in names
+    assert "thenvoi_list_contacts" not in names
+
+
+async def test_scope_agent_human_tools_contacts_exposes_resolve_handle() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["agent", "human"],
+        tools=["contacts"],
+        agent_key="a",
+        user_key="u",
+    )
+    register_tools(mcp, cfg)
+    names = {t.name for t in await mcp.list_tools()}
+
+    assert "thenvoi_resolve_handle" in names
+    assert "thenvoi_list_my_contacts" in names
+    assert "thenvoi_list_contacts" in names
+
+
+async def test_scope_agent_human_tools_memory_exposes_memory_tools() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["agent", "human"],
+        tools=["memory"],
+        agent_key="a",
+        user_key="u",
+    )
+    register_tools(mcp, cfg)
+    names = {t.name for t in await mcp.list_tools()}
+
+    assert "thenvoi_list_user_memories" in names
+    assert "thenvoi_store_memory" in names
+
+
+async def test_scope_agent_human_tools_contacts_memory_exposes_both() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["agent", "human"],
+        tools=["contacts", "memory"],
+        agent_key="a",
+        user_key="u",
+    )
+    register_tools(mcp, cfg)
+    names = {t.name for t in await mcp.list_tools()}
+
+    assert "thenvoi_list_my_contacts" in names
+    assert "thenvoi_list_user_memories" in names
+
+
+# ---------------------------------------------------------------------------
+# --scope human only
+# ---------------------------------------------------------------------------
+
+
+async def test_scope_human_only_does_not_register_agent_tools() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["human"], tools=[], user_key="u")
+    register_tools(mcp, cfg)
+    names = {t.name for t in await mcp.list_tools()}
+
+    # Human tools present
+    assert "thenvoi_list_my_chats" in names
+    # Agent tools absent
+    assert "thenvoi_send_message" not in names
+    assert "thenvoi_get_participants" not in names
+
+
+async def test_call_agent_tool_in_human_only_scope_is_unknown() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["human"], tools=[], user_key="u")
+    register_tools(mcp, cfg)
+
+    # FastMCP surfaces unknown tools as ToolError("Unknown tool: ...").
+    with pytest.raises(Exception) as excinfo:
+        await mcp._tool_manager.call_tool("thenvoi_send_message", {})
+    assert "Unknown tool" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# --room-id r_pinned: schema strips chat_id/room_id; pin is injected
+# ---------------------------------------------------------------------------
+
+
+async def test_pinned_mode_agent_send_message_dispatches_to_pinned_room() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["agent"], tools=[], agent_key="a", room_id="r_pinned")
+    register_tools(mcp, cfg)
+
+    # Schema should NOT advertise chat_id or room_id
+    tool = next(t for t in await mcp.list_tools() if t.name == "thenvoi_send_message")
+    props = tool.inputSchema.get("properties", {})
+    assert "chat_id" not in props
+    assert "room_id" not in props
+
+    # Dispatch with NO chat_id → pinned room is used.
+    agent_tools = MagicMock()
+    agent_tools.send_message = AsyncMock(return_value={"ok": True})
+    app_ctx = _FakeAppCtx(agent_tools_by_room={"r_pinned": agent_tools})
+
+    result = await mcp._tool_manager.call_tool(
+        "thenvoi_send_message",
+        {"content": "hi", "mentions": ["@bob"]},
+        context=_FakeCtx(app_ctx),
+    )
+    agent_tools.send_message.assert_awaited_once()
+    call_kwargs = agent_tools.send_message.await_args.kwargs
+    assert "chat_id" not in call_kwargs  # stripped before method call
+    # Reset called once for this invocation.
+    assert app_ctx._cache_reset_count == 1
+    # Result serialized to JSON
+    assert "ok" in str(result)
+
+
+async def test_pinned_mode_human_send_message_dispatches_with_pinned_chat_id() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["human"], tools=[], user_key="u", room_id="r_pinned")
+    register_tools(mcp, cfg)
+
+    tool = next(
+        t for t in await mcp.list_tools() if t.name == "thenvoi_send_my_chat_message"
+    )
+    props = tool.inputSchema.get("properties", {})
+    assert "chat_id" not in props
+
+    human_tools = MagicMock()
+    human_tools.send_my_chat_message = AsyncMock(return_value={"ok": True})
+    app_ctx = _FakeAppCtx(human_tools=human_tools)
+
+    result = await mcp._tool_manager.call_tool(
+        "thenvoi_send_my_chat_message",
+        {"content": "hi", "recipients": "@bob"},
+        context=_FakeCtx(app_ctx),
+    )
+    call_kwargs = human_tools.send_my_chat_message.await_args.kwargs
+    assert call_kwargs["chat_id"] == "r_pinned"  # pin injected
+    assert "ok" in str(result)
+
+
+async def test_pinned_mode_room_less_human_tool_unchanged() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["human"], tools=[], user_key="u", room_id="r_pinned")
+    register_tools(mcp, cfg)
+
+    tool = next(t for t in await mcp.list_tools() if t.name == "thenvoi_list_my_chats")
+    props = tool.inputSchema.get("properties", {})
+    assert "chat_id" not in props  # it was never there to begin with
+    # Tool still listed and callable.
+    human_tools = MagicMock()
+    human_tools.list_my_chats = AsyncMock(return_value={"data": []})
+    app_ctx = _FakeAppCtx(human_tools=human_tools)
+
+    await mcp._tool_manager.call_tool(
+        "thenvoi_list_my_chats", {}, context=_FakeCtx(app_ctx)
+    )
+    human_tools.list_my_chats.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Unpinned dispatch: chat_id and room_id both route to the same room
+# ---------------------------------------------------------------------------
+
+
+async def test_unpinned_agent_dispatch_via_chat_id() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["agent"], tools=[], agent_key="a")
+    register_tools(mcp, cfg)
+
+    agent_tools = MagicMock()
+    agent_tools.send_message = AsyncMock(return_value={"id": "msg_1"})
+    app_ctx = _FakeAppCtx(agent_tools_by_room={"r_abc": agent_tools})
+
+    await mcp._tool_manager.call_tool(
+        "thenvoi_send_message",
+        {"content": "hi", "mentions": ["@bob"], "chat_id": "r_abc"},
+        context=_FakeCtx(app_ctx),
+    )
+    agent_tools.send_message.assert_awaited_once()
+
+
+async def test_unpinned_agent_dispatch_via_room_id_alias() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["agent"], tools=[], agent_key="a")
+    register_tools(mcp, cfg)
+
+    agent_tools = MagicMock()
+    agent_tools.send_message = AsyncMock(return_value={"id": "msg_1"})
+    app_ctx = _FakeAppCtx(agent_tools_by_room={"r_xyz": agent_tools})
+
+    # Client sends "room_id" — the alias routes to chat_id internally.
+    await mcp._tool_manager.call_tool(
+        "thenvoi_send_message",
+        {"content": "hi", "mentions": ["@bob"], "room_id": "r_xyz"},
+        context=_FakeCtx(app_ctx),
+    )
+    agent_tools.send_message.assert_awaited_once()

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Marker file for the `tests.unit` package."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,447 @@
+"""Unit tests for `thenvoi_mcp.config`.
+
+Covers Phase 2 (INT-350) acceptance criteria:
+- Precedence per slot: CLI > THENVOI_* > BAND_* > THENVOI_API_KEY (legacy only).
+- Scope-specific key wins; legacy is fallback + emits warning when masked.
+- `--scope` / `--tools` parsing (comma-separated, repeatable, explicit empty).
+- Unknown values produce warnings with `did_you_mean` and are dropped.
+- `validate()` fail-fast per scope/credential.
+- `room_id` resolution.
+- `ConfigWarning` dataclass shape.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from thenvoi_mcp.config import (
+    Config,
+    ConfigError,
+    ConfigWarning,
+    _suggest_value,
+    resolve_config,
+    resolve_credential_for_scope,
+    validate,
+)
+
+
+# ---------------------------------------------------------------------------
+# Dataclass shape
+# ---------------------------------------------------------------------------
+
+
+def test_config_warning_is_frozen_dataclass():
+    w = ConfigWarning(
+        kind="unknown-tools-value",
+        value="contact",
+        did_you_mean="contacts",
+        message="msg",
+    )
+    assert dataclasses.is_dataclass(w)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        w.kind = "legacy-key-ignored"  # type: ignore[misc]
+
+
+def test_config_warning_fields():
+    fields = {f.name for f in dataclasses.fields(ConfigWarning)}
+    assert fields == {"kind", "value", "did_you_mean", "message"}
+
+
+# ---------------------------------------------------------------------------
+# _suggest_value
+# ---------------------------------------------------------------------------
+
+
+def test_suggest_value_close_match():
+    assert _suggest_value("contact", ["contacts", "memory"]) == "contacts"
+    assert _suggest_value("huamn", ["agent", "human"]) == "human"
+    assert _suggest_value("agnet", ["agent", "human"]) == "agent"
+
+
+def test_suggest_value_no_match():
+    assert _suggest_value("zzz", ["contacts", "memory"]) is None
+
+
+# ---------------------------------------------------------------------------
+# Credential precedence per slot
+# ---------------------------------------------------------------------------
+
+
+def test_user_key_cli_beats_thenvoi_env():
+    cfg = resolve_config(
+        cli={"user_key": "cli_user"},
+        env={"THENVOI_USER_KEY": "env_thenvoi", "BAND_USER_KEY": "env_band"},
+    )
+    assert cfg.user_key == "cli_user"
+
+
+def test_user_key_thenvoi_beats_band():
+    cfg = resolve_config(
+        cli={},
+        env={"THENVOI_USER_KEY": "env_thenvoi", "BAND_USER_KEY": "env_band"},
+    )
+    assert cfg.user_key == "env_thenvoi"
+
+
+def test_user_key_band_when_only_band_set():
+    cfg = resolve_config(cli={}, env={"BAND_USER_KEY": "band_only"})
+    assert cfg.user_key == "band_only"
+
+
+def test_user_key_none_when_nothing_set():
+    cfg = resolve_config(cli={}, env={})
+    assert cfg.user_key is None
+
+
+def test_agent_key_precedence_chain():
+    # CLI beats THENVOI_* beats BAND_*
+    cfg = resolve_config(
+        cli={"agent_key": "cli_a"},
+        env={"THENVOI_AGENT_KEY": "env_t", "BAND_AGENT_KEY": "env_b"},
+    )
+    assert cfg.agent_key == "cli_a"
+
+    cfg = resolve_config(
+        cli={}, env={"THENVOI_AGENT_KEY": "env_t", "BAND_AGENT_KEY": "env_b"}
+    )
+    assert cfg.agent_key == "env_t"
+
+    cfg = resolve_config(cli={}, env={"BAND_AGENT_KEY": "env_b"})
+    assert cfg.agent_key == "env_b"
+
+
+def test_legacy_key_only_from_thenvoi_api_key():
+    cfg = resolve_config(cli={}, env={"THENVOI_API_KEY": "thnv_u_abc"})
+    assert cfg.legacy_key == "thnv_u_abc"
+    # legacy doesn't populate user_key/agent_key directly
+    assert cfg.user_key is None
+    assert cfg.agent_key is None
+
+
+# ---------------------------------------------------------------------------
+# Cross-slot precedence (legacy masking)
+# ---------------------------------------------------------------------------
+
+
+def test_user_key_masks_legacy_human_capable():
+    cfg = resolve_config(
+        cli={}, env={"THENVOI_USER_KEY": "user_1", "THENVOI_API_KEY": "thnv_u_xxx"}
+    )
+    # user_key populated; for human, user_key wins
+    assert resolve_credential_for_scope(cfg, "human") == "user_1"
+    # legacy ignored warning emitted
+    kinds = [w.kind for w in cfg.warnings]
+    assert "legacy-key-ignored" in kinds
+
+
+def test_agent_key_masks_legacy_all_capable():
+    cfg = resolve_config(
+        cli={}, env={"THENVOI_AGENT_KEY": "agent_1", "THENVOI_API_KEY": "thnv_abc"}
+    )
+    # agent_key wins for agent scope
+    assert resolve_credential_for_scope(cfg, "agent") == "agent_1"
+    # Legacy is all-capable → it's masked for agent; still emits warning.
+    assert any(w.kind == "legacy-key-ignored" for w in cfg.warnings)
+    # Legacy still usable as fallback for human (user_key not set).
+    assert resolve_credential_for_scope(cfg, "human") == "thnv_abc"
+
+
+def test_no_legacy_warning_when_no_overlap():
+    # legacy_key is agent-only (thnv_a_) and only user_key is set → no overlap,
+    # no warning.
+    cfg = resolve_config(
+        cli={}, env={"THENVOI_USER_KEY": "user_1", "THENVOI_API_KEY": "thnv_a_xxx"}
+    )
+    assert all(w.kind != "legacy-key-ignored" for w in cfg.warnings)
+
+
+def test_legacy_fallback_when_scope_key_empty():
+    cfg = resolve_config(cli={}, env={"THENVOI_API_KEY": "thnv_abc"})
+    assert resolve_credential_for_scope(cfg, "human") == "thnv_abc"
+    assert resolve_credential_for_scope(cfg, "agent") == "thnv_abc"
+
+
+# ---------------------------------------------------------------------------
+# Room id
+# ---------------------------------------------------------------------------
+
+
+def test_room_id_precedence():
+    cfg = resolve_config(
+        cli={"room_id": "cli_room"},
+        env={"THENVOI_MCP_ROOM_ID": "env_t", "BAND_MCP_ROOM_ID": "env_b"},
+    )
+    assert cfg.room_id == "cli_room"
+
+    cfg = resolve_config(
+        cli={}, env={"THENVOI_MCP_ROOM_ID": "env_t", "BAND_MCP_ROOM_ID": "env_b"}
+    )
+    assert cfg.room_id == "env_t"
+
+    cfg = resolve_config(cli={}, env={"BAND_MCP_ROOM_ID": "env_b"})
+    assert cfg.room_id == "env_b"
+
+
+def test_room_id_defaults_none():
+    cfg = resolve_config(cli={}, env={})
+    assert cfg.room_id is None
+
+
+# ---------------------------------------------------------------------------
+# --scope parsing
+# ---------------------------------------------------------------------------
+
+
+def test_scope_default_is_agent():
+    cfg = resolve_config(cli={}, env={})
+    assert cfg.scope == ["agent"]
+
+
+def test_scope_comma_separated():
+    cfg = resolve_config(cli={"scope": "agent,human"}, env={})
+    assert cfg.scope == ["agent", "human"]
+
+
+def test_scope_repeatable_list():
+    cfg = resolve_config(cli={"scope": ["agent", "human"]}, env={})
+    assert cfg.scope == ["agent", "human"]
+
+
+def test_scope_repeatable_mixed_with_csv():
+    cfg = resolve_config(cli={"scope": ["agent,human", "agent"]}, env={})
+    # de-duped, order preserved
+    assert cfg.scope == ["agent", "human"]
+
+
+def test_scope_precedence_cli_over_env():
+    cfg = resolve_config(
+        cli={"scope": "human"},
+        env={"THENVOI_MCP_SCOPE": "agent", "BAND_MCP_SCOPE": "agent,human"},
+    )
+    assert cfg.scope == ["human"]
+
+
+def test_scope_thenvoi_env_beats_band_env():
+    cfg = resolve_config(
+        cli={},
+        env={"THENVOI_MCP_SCOPE": "human", "BAND_MCP_SCOPE": "agent"},
+    )
+    assert cfg.scope == ["human"]
+
+
+def test_scope_band_env_when_no_thenvoi():
+    cfg = resolve_config(cli={}, env={"BAND_MCP_SCOPE": "human"})
+    assert cfg.scope == ["human"]
+
+
+def test_scope_unknown_value_warned_and_dropped():
+    cfg = resolve_config(cli={"scope": "agent,agnet"}, env={})
+    assert cfg.scope == ["agent"]
+    warns = [w for w in cfg.warnings if w.kind == "unknown-scope-value"]
+    assert len(warns) == 1
+    assert warns[0].value == "agnet"
+    assert warns[0].did_you_mean == "agent"
+
+
+def test_scope_unknown_huamn_suggests_human():
+    cfg = resolve_config(cli={"scope": "huamn"}, env={})
+    warns = [w for w in cfg.warnings if w.kind == "unknown-scope-value"]
+    assert warns[0].did_you_mean == "human"
+
+
+# ---------------------------------------------------------------------------
+# --tools parsing
+# ---------------------------------------------------------------------------
+
+
+def test_tools_default_empty():
+    cfg = resolve_config(cli={}, env={})
+    assert cfg.tools == []
+
+
+def test_tools_comma_separated():
+    cfg = resolve_config(cli={"tools": "contacts,memory"}, env={})
+    assert cfg.tools == ["contacts", "memory"]
+
+
+def test_tools_repeatable():
+    cfg = resolve_config(cli={"tools": ["contacts", "memory"]}, env={})
+    assert cfg.tools == ["contacts", "memory"]
+
+
+def test_tools_explicit_empty_string_overrides_env():
+    cfg = resolve_config(cli={"tools": ""}, env={"THENVOI_MCP_TOOLS": "contacts"})
+    assert cfg.tools == []
+
+
+def test_tools_precedence():
+    cfg = resolve_config(
+        cli={"tools": "memory"},
+        env={"THENVOI_MCP_TOOLS": "contacts", "BAND_MCP_TOOLS": "contacts,memory"},
+    )
+    assert cfg.tools == ["memory"]
+
+    cfg = resolve_config(
+        cli={}, env={"THENVOI_MCP_TOOLS": "contacts", "BAND_MCP_TOOLS": "memory"}
+    )
+    assert cfg.tools == ["contacts"]
+
+    cfg = resolve_config(cli={}, env={"BAND_MCP_TOOLS": "memory"})
+    assert cfg.tools == ["memory"]
+
+
+def test_tools_unknown_value_with_suggestion():
+    cfg = resolve_config(cli={"tools": "contact"}, env={})
+    assert cfg.tools == []
+    warns = [w for w in cfg.warnings if w.kind == "unknown-tools-value"]
+    assert len(warns) == 1
+    assert warns[0].value == "contact"
+    assert warns[0].did_you_mean == "contacts"
+
+
+def test_tools_unknown_value_no_suggestion():
+    cfg = resolve_config(cli={"tools": "zzz"}, env={})
+    warns = [w for w in cfg.warnings if w.kind == "unknown-tools-value"]
+    assert len(warns) == 1
+    assert warns[0].value == "zzz"
+    assert warns[0].did_you_mean is None
+
+
+def test_tools_known_and_unknown_mixed():
+    cfg = resolve_config(cli={"tools": "contacts,zzz,memory"}, env={})
+    assert cfg.tools == ["contacts", "memory"]
+    assert any(
+        w.kind == "unknown-tools-value" and w.value == "zzz" for w in cfg.warnings
+    )
+
+
+# ---------------------------------------------------------------------------
+# validate()
+# ---------------------------------------------------------------------------
+
+
+def test_validate_passes_with_agent_key_agent_scope():
+    cfg = resolve_config(cli={"agent_key": "thnv_a_1"}, env={})
+    # Default scope is ["agent"]; agent_key set -> ok
+    validate(cfg)
+
+
+def test_validate_fails_agent_scope_missing_agent_key():
+    cfg = resolve_config(cli={}, env={})
+    with pytest.raises(ConfigError):
+        validate(cfg)
+
+
+def test_validate_fails_human_scope_missing_user_key():
+    cfg = resolve_config(cli={"scope": "human", "agent_key": "thnv_a_1"}, env={})
+    with pytest.raises(ConfigError):
+        validate(cfg)
+
+
+def test_validate_passes_human_scope_with_user_key():
+    cfg = resolve_config(cli={"scope": "human", "user_key": "thnv_u_1"}, env={})
+    validate(cfg)
+
+
+def test_validate_passes_via_legacy_key_agent_capable():
+    # thnv_a_ legacy satisfies agent scope
+    cfg = resolve_config(cli={}, env={"THENVOI_API_KEY": "thnv_a_xyz"})
+    validate(cfg)
+
+
+def test_validate_passes_via_legacy_key_all_capable_both_scopes():
+    cfg = resolve_config(
+        cli={"scope": "agent,human"}, env={"THENVOI_API_KEY": "thnv_xyz"}
+    )
+    validate(cfg)
+
+
+def test_validate_fails_human_scope_with_agent_only_legacy():
+    cfg = resolve_config(
+        cli={"scope": "agent,human"}, env={"THENVOI_API_KEY": "thnv_a_xyz"}
+    )
+    with pytest.raises(ConfigError):
+        validate(cfg)
+
+
+def test_validate_fails_agent_scope_with_human_only_legacy():
+    cfg = resolve_config(cli={}, env={"THENVOI_API_KEY": "thnv_u_xyz"})
+    with pytest.raises(ConfigError):
+        validate(cfg)
+
+
+def test_validate_fails_on_empty_scope():
+    # Only unknown scope values → resolved scope is empty → validate fails.
+    cfg = resolve_config(cli={"scope": "zzzzz"}, env={"THENVOI_API_KEY": "thnv_xyz"})
+    # Defensive: empty scope should raise, since no scope means "serve nothing".
+    with pytest.raises(ConfigError):
+        validate(cfg)
+
+
+# ---------------------------------------------------------------------------
+# Full Config shape
+# ---------------------------------------------------------------------------
+
+
+def test_config_has_expected_fields():
+    fields = {f.name for f in dataclasses.fields(Config)}
+    assert fields == {
+        "user_key",
+        "agent_key",
+        "room_id",
+        "scope",
+        "tools",
+        "legacy_key",
+        "warnings",
+    }
+
+
+def test_config_full_resolution_example():
+    cfg = resolve_config(
+        cli={
+            "user_key": "thnv_u_cli",
+            "agent_key": "thnv_a_cli",
+            "room_id": "r_cli",
+            "scope": "agent,human",
+            "tools": "contacts,memory",
+        },
+        env={},
+    )
+    assert cfg.user_key == "thnv_u_cli"
+    assert cfg.agent_key == "thnv_a_cli"
+    assert cfg.room_id == "r_cli"
+    assert cfg.scope == ["agent", "human"]
+    assert cfg.tools == ["contacts", "memory"]
+    assert cfg.legacy_key is None
+    assert cfg.warnings == []
+    validate(cfg)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Warning message format (sanity)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_tools_warning_message_includes_suggestion():
+    cfg = resolve_config(cli={"tools": "contact"}, env={})
+    warn = next(w for w in cfg.warnings if w.kind == "unknown-tools-value")
+    assert "did you mean 'contacts'" in warn.message
+    assert "'contact'" in warn.message
+
+
+def test_unknown_tools_warning_message_lists_valid_when_no_suggestion():
+    cfg = resolve_config(cli={"tools": "zzz"}, env={})
+    warn = next(w for w in cfg.warnings if w.kind == "unknown-tools-value")
+    assert "contacts" in warn.message
+    assert "memory" in warn.message
+
+
+def test_legacy_ignored_warning_value_field():
+    cfg = resolve_config(
+        cli={}, env={"THENVOI_USER_KEY": "u", "THENVOI_API_KEY": "thnv_u_x"}
+    )
+    warn = next(w for w in cfg.warnings if w.kind == "legacy-key-ignored")
+    assert warn.value == "legacy_key"
+    assert warn.did_you_mean is None

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -49,6 +49,22 @@ def test_config_warning_fields():
     assert fields == {"kind", "value", "did_you_mean", "message"}
 
 
+def test_config_default_scope_is_agent():
+    # AC #6: default scope is ["agent"]. A bare `Config()` must honor it so
+    # test fixtures and external callers don't silently fail validate().
+    cfg = Config()
+    assert cfg.scope == ["agent"]
+    assert cfg.tools == []
+
+
+def test_config_default_scope_isolated_between_instances():
+    # Guard against the classic mutable-default-argument bug.
+    a = Config()
+    b = Config()
+    a.scope.append("human")
+    assert b.scope == ["agent"]
+
+
 # ---------------------------------------------------------------------------
 # _suggest_value
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -20,6 +20,7 @@ from thenvoi_mcp.config import (
     Config,
     ConfigError,
     ConfigWarning,
+    _legacy_key_capabilities,
     _suggest_value,
     resolve_config,
     resolve_credential_for_scope,
@@ -55,6 +56,12 @@ def test_config_default_scope_is_agent():
     cfg = Config()
     assert cfg.scope == ["agent"]
     assert cfg.tools == []
+
+
+def test_config_is_frozen_dataclass():
+    cfg = Config()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cfg.scope = ["human"]  # type: ignore[misc]
 
 
 def test_config_default_scope_isolated_between_instances():
@@ -134,6 +141,22 @@ def test_legacy_key_only_from_thenvoi_api_key():
     # legacy doesn't populate user_key/agent_key directly
     assert cfg.user_key is None
     assert cfg.agent_key is None
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        ("thnv_u_abc", (True, False)),
+        ("band_u_abc", (True, False)),
+        ("thnv_a_abc", (False, True)),
+        ("band_a_abc", (False, True)),
+        ("thnv_abc", (True, True)),
+        ("band_abc", (True, True)),
+        ("other_abc", (False, False)),
+    ],
+)
+def test_legacy_key_capabilities_accept_thenvoi_and_band_prefixes(key, expected):
+    assert _legacy_key_capabilities(key) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -289,6 +312,11 @@ def test_tools_repeatable():
 
 def test_tools_explicit_empty_string_overrides_env():
     cfg = resolve_config(cli={"tools": ""}, env={"THENVOI_MCP_TOOLS": "contacts"})
+    assert cfg.tools == []
+
+
+def test_tools_explicit_empty_argparse_list_overrides_env():
+    cfg = resolve_config(cli={"tools": [""]}, env={"THENVOI_MCP_TOOLS": "contacts"})
     assert cfg.tools == []
 
 

--- a/tests/unit/test_registrar.py
+++ b/tests/unit/test_registrar.py
@@ -15,16 +15,16 @@ Covers Phase 3 (INT-351) acceptance criteria:
 from __future__ import annotations
 
 import asyncio
+import sys
+import types
+from dataclasses import dataclass
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from mcp.server.fastmcp import FastMCP
+from pydantic import BaseModel
 
-from thenvoi.runtime.tools import (  # type: ignore[import-not-found]
-    TOOL_DEFINITIONS,
-    iter_tool_definitions,
-)
 from thenvoi_mcp.config import Config
 from thenvoi_mcp.tools import registrar
 from thenvoi_mcp.tools.registrar import (
@@ -35,6 +35,127 @@ from thenvoi_mcp.tools.registrar import (
     make_handler,
     register_tools,
 )
+
+
+class _SendMessageInput(BaseModel):
+    """Send a message."""
+
+    content: str
+    mentions: list[str]
+
+
+class _SimpleContentInput(BaseModel):
+    """Send event content."""
+
+    content: str
+
+
+class _IdentifierInput(BaseModel):
+    """Participant identifier."""
+
+    identifier: str
+
+
+class _LookupPeersInput(BaseModel):
+    """Lookup peers."""
+
+    query: str | None = None
+
+
+class _NoInput(BaseModel):
+    """No input."""
+
+
+class _HumanSendMessageInput(BaseModel):
+    """Send a human chat message."""
+
+    chat_id: str
+    content: str
+    recipients: str
+
+
+class _ResolveHandleInput(BaseModel):
+    """Resolve a handle."""
+
+    handle: str
+
+
+@dataclass(frozen=True)
+class _ToolDefinition:
+    name: str
+    surface: str
+    method_name: str
+    input_model: type[BaseModel]
+    category: str = "core"
+
+
+_TOOL_DEFINITIONS_LIST = [
+    _ToolDefinition("thenvoi_send_message", "agent", "send_message", _SendMessageInput),
+    _ToolDefinition("thenvoi_send_event", "agent", "send_event", _SimpleContentInput),
+    _ToolDefinition(
+        "thenvoi_add_participant", "agent", "add_participant", _IdentifierInput
+    ),
+    _ToolDefinition(
+        "thenvoi_remove_participant", "agent", "remove_participant", _IdentifierInput
+    ),
+    _ToolDefinition("thenvoi_get_participants", "agent", "get_participants", _NoInput),
+    _ToolDefinition("thenvoi_lookup_peers", "agent", "lookup_peers", _LookupPeersInput),
+    _ToolDefinition("thenvoi_create_chatroom", "agent", "create_chatroom", _NoInput),
+    _ToolDefinition(
+        "thenvoi_list_memories", "agent", "list_memories", _NoInput, "memory"
+    ),
+    _ToolDefinition(
+        "thenvoi_send_my_chat_message",
+        "human",
+        "send_my_chat_message",
+        _HumanSendMessageInput,
+    ),
+    _ToolDefinition("thenvoi_list_my_chats", "human", "list_my_chats", _NoInput),
+    _ToolDefinition("thenvoi_get_my_profile", "human", "get_my_profile", _NoInput),
+    _ToolDefinition(
+        "thenvoi_list_my_contacts", "human", "list_my_contacts", _NoInput, "contacts"
+    ),
+    _ToolDefinition(
+        "thenvoi_resolve_handle",
+        "human",
+        "resolve_handle",
+        _ResolveHandleInput,
+        "contacts",
+    ),
+    _ToolDefinition(
+        "thenvoi_list_user_memories", "human", "list_user_memories", _NoInput, "memory"
+    ),
+]
+TOOL_DEFINITIONS = {
+    definition.name: definition for definition in _TOOL_DEFINITIONS_LIST
+}
+
+
+def iter_tool_definitions(
+    *,
+    surface: str,
+    include_contacts: bool = False,
+    include_memory: bool = False,
+) -> list[_ToolDefinition]:
+    definitions = [d for d in _TOOL_DEFINITIONS_LIST if d.surface == surface]
+    return [
+        d
+        for d in definitions
+        if (d.category != "contacts" or include_contacts)
+        and (d.category != "memory" or include_memory)
+    ]
+
+
+_fake_thenvoi_tools = types.ModuleType("thenvoi.runtime.tools")
+_fake_thenvoi_tools.TOOL_DEFINITIONS = TOOL_DEFINITIONS
+_fake_thenvoi_tools.iter_tool_definitions = iter_tool_definitions
+_fake_thenvoi_runtime = types.ModuleType("thenvoi.runtime")
+_fake_thenvoi_runtime.tools = _fake_thenvoi_tools
+_fake_thenvoi = types.ModuleType("thenvoi")
+_fake_thenvoi.runtime = _fake_thenvoi_runtime
+sys.modules.setdefault("thenvoi", _fake_thenvoi)
+sys.modules.setdefault("thenvoi.runtime", _fake_thenvoi_runtime)
+sys.modules.setdefault("thenvoi.runtime.tools", _fake_thenvoi_tools)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_registrar.py
+++ b/tests/unit/test_registrar.py
@@ -1,0 +1,601 @@
+"""Unit tests for ``thenvoi_mcp.tools.registrar``.
+
+Covers Phase 3 (INT-351) acceptance criteria:
+- Scope-filtered registration matches ``iter_tool_definitions(surface=...)``.
+- ``--tools contacts`` / ``--tools memory`` flow into ``iter_tool_definitions``.
+- Agent room-bound tools get a ``chat_id`` field added to the advertised schema.
+- ``AliasChoices("chat_id", "room_id")`` accepts both names inbound.
+- Pinned mode hides ``chat_id`` from advertised schema for both surfaces.
+- Handler invokes ``get_agent_tools(ctx, chat_id)`` / ``get_human_tools(ctx)``.
+- Handler strips ``chat_id`` from kwargs before calling ``AgentTools.<method>``.
+- Handler re-calls ``reset_agent_tools_cache(ctx)`` at the start of each invocation.
+- Room-less tools are registered unchanged regardless of pin state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from thenvoi.runtime.tools import (  # type: ignore[import-not-found]
+    TOOL_DEFINITIONS,
+    iter_tool_definitions,
+)
+from thenvoi_mcp.config import Config
+from thenvoi_mcp.tools import registrar
+from thenvoi_mcp.tools.registrar import (
+    AGENT_ROOM_BOUND_TOOL_NAMES,
+    _classify_tool,
+    _extend_with_chat_id,
+    _pin_existing_chat_id,
+    make_handler,
+    register_tools,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _registered_names(mcp: FastMCP) -> set[str]:
+    tools = asyncio.new_event_loop().run_until_complete(mcp.list_tools())
+    return {t.name for t in tools}
+
+
+async def _list_tool(mcp: FastMCP, name: str) -> Any:
+    tools = await mcp.list_tools()
+    for t in tools:
+        if t.name == name:
+            return t
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Scope filtering
+# ---------------------------------------------------------------------------
+
+
+def test_scope_agent_only_registers_agent_surface() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["agent"], tools=[], agent_key="k")
+    register_tools(mcp, cfg)
+
+    expected = {
+        d.name
+        for d in iter_tool_definitions(
+            surface="agent", include_contacts=False, include_memory=False
+        )
+    }
+    assert _registered_names(mcp) == expected
+
+
+def test_scope_human_only_registers_human_surface() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["human"], tools=[], user_key="k")
+    register_tools(mcp, cfg)
+
+    expected = {
+        d.name
+        for d in iter_tool_definitions(
+            surface="human", include_contacts=False, include_memory=False
+        )
+    }
+    assert _registered_names(mcp) == expected
+
+
+def test_scope_both_registers_union() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["agent", "human"], tools=[], agent_key="a", user_key="u")
+    register_tools(mcp, cfg)
+
+    expected = set()
+    for s in ("agent", "human"):
+        expected |= {
+            d.name
+            for d in iter_tool_definitions(
+                surface=s, include_contacts=False, include_memory=False
+            )
+        }
+    assert _registered_names(mcp) == expected
+
+
+# ---------------------------------------------------------------------------
+# --tools contacts / --tools memory propagation
+# ---------------------------------------------------------------------------
+
+
+def test_tools_contacts_registers_contact_tools() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["agent", "human"],
+        tools=["contacts"],
+        agent_key="a",
+        user_key="u",
+    )
+    register_tools(mcp, cfg)
+    names = _registered_names(mcp)
+
+    assert "thenvoi_list_my_contacts" in names
+    assert "thenvoi_resolve_handle" in names
+    # Memory stays off
+    assert "thenvoi_list_memories" not in names
+    assert "thenvoi_list_user_memories" not in names
+
+
+def test_tools_memory_registers_memory_tools() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["agent", "human"],
+        tools=["memory"],
+        agent_key="a",
+        user_key="u",
+    )
+    register_tools(mcp, cfg)
+    names = _registered_names(mcp)
+
+    assert "thenvoi_list_memories" in names
+    assert "thenvoi_list_user_memories" in names
+    # Contacts stay off
+    assert "thenvoi_list_my_contacts" not in names
+
+
+def test_tools_both_registers_both_groups() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["agent", "human"],
+        tools=["contacts", "memory"],
+        agent_key="a",
+        user_key="u",
+    )
+    register_tools(mcp, cfg)
+    names = _registered_names(mcp)
+
+    assert "thenvoi_list_my_contacts" in names
+    assert "thenvoi_list_memories" in names
+
+
+def test_tools_empty_disables_both() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["agent", "human"],
+        tools=[],
+        agent_key="a",
+        user_key="u",
+    )
+    register_tools(mcp, cfg)
+    names = _registered_names(mcp)
+
+    assert "thenvoi_list_memories" not in names
+    assert "thenvoi_list_user_memories" not in names
+    assert "thenvoi_list_my_contacts" not in names
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def test_agent_room_bound_constant_matches_classifier() -> None:
+    for name in AGENT_ROOM_BOUND_TOOL_NAMES:
+        definition = TOOL_DEFINITIONS[name]
+        is_agent, is_human = _classify_tool(definition)
+        assert is_agent is True
+        assert is_human is False
+
+
+def test_agent_room_less_tool_not_classified_room_bound() -> None:
+    # thenvoi_create_chatroom does not take a room id on the agent surface.
+    definition = TOOL_DEFINITIONS["thenvoi_create_chatroom"]
+    is_agent, is_human = _classify_tool(definition)
+    assert is_agent is False
+    assert is_human is False
+
+
+def test_human_chat_id_tool_classified_room_bound() -> None:
+    definition = TOOL_DEFINITIONS["thenvoi_send_my_chat_message"]
+    is_agent, is_human = _classify_tool(definition)
+    assert is_agent is False
+    assert is_human is True
+
+
+def test_human_room_less_tool_not_classified_room_bound() -> None:
+    definition = TOOL_DEFINITIONS["thenvoi_list_my_chats"]
+    is_agent, is_human = _classify_tool(definition)
+    assert is_agent is False
+    assert is_human is False
+
+
+# ---------------------------------------------------------------------------
+# Unpinned agent handler: schema + dispatch
+# ---------------------------------------------------------------------------
+
+
+async def test_unpinned_agent_schema_includes_chat_id() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["agent"], tools=[], agent_key="k")
+    register_tools(mcp, cfg)
+
+    t = await _list_tool(mcp, "thenvoi_send_message")
+    assert t is not None
+    props = t.inputSchema.get("properties", {})
+    required = t.inputSchema.get("required", [])
+    assert "chat_id" in props
+    assert "chat_id" in required
+    # Room-less agent tool: no chat_id in schema.
+    cr = await _list_tool(mcp, "thenvoi_create_chatroom")
+    assert cr is not None
+    assert "chat_id" not in cr.inputSchema.get("properties", {})
+
+
+def test_agent_room_bound_model_accepts_room_id_alias() -> None:
+    definition = TOOL_DEFINITIONS["thenvoi_send_message"]
+    extended = _extend_with_chat_id(definition.input_model, None)
+    v1 = extended.model_validate({"content": "hi", "mentions": ["@x"], "room_id": "r1"})
+    assert v1.chat_id == "r1"
+    v2 = extended.model_validate({"content": "hi", "mentions": ["@x"], "chat_id": "r2"})
+    assert v2.chat_id == "r2"
+
+
+async def test_unpinned_agent_handler_calls_get_agent_tools_with_chat_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Fake AgentTools method
+    fake_agent_tools = MagicMock()
+    fake_agent_tools.send_message = AsyncMock(return_value={"ok": True})
+
+    get_agent_tools_spy = MagicMock(return_value=fake_agent_tools)
+    reset_spy = MagicMock()
+
+    monkeypatch.setattr(registrar, "get_agent_tools", get_agent_tools_spy)
+    monkeypatch.setattr(registrar, "reset_agent_tools_cache", reset_spy)
+    monkeypatch.setattr(registrar, "get_human_tools", MagicMock())
+
+    definition = TOOL_DEFINITIONS["thenvoi_send_message"]
+    extended = _extend_with_chat_id(definition.input_model, None)
+
+    handler = make_handler(
+        tool_name=definition.name,
+        surface="agent",
+        method_name=definition.method_name,
+        input_model=extended,
+        pinned_room_id=None,
+        is_agent_room_bound=True,
+        is_human_room_bound=False,
+    )
+
+    ctx = MagicMock()
+    out = await handler(ctx=ctx, content="hello", mentions=["@bob"], chat_id="r1")
+
+    reset_spy.assert_called_once_with(ctx)
+    get_agent_tools_spy.assert_called_once_with(ctx, "r1")
+    # chat_id must NOT reach the AgentTools method call — AgentTools is
+    # constructor-scoped and its methods don't take chat_id.
+    fake_agent_tools.send_message.assert_awaited_once()
+    call_kwargs = fake_agent_tools.send_message.await_args.kwargs
+    assert "chat_id" not in call_kwargs
+    assert call_kwargs == {"content": "hello", "mentions": ["@bob"]}
+    assert "ok" in out
+
+
+async def test_unpinned_agent_handler_accepts_room_id_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_agent_tools = MagicMock()
+    fake_agent_tools.send_message = AsyncMock(return_value={"ok": True})
+    get_agent_tools_spy = MagicMock(return_value=fake_agent_tools)
+    monkeypatch.setattr(registrar, "get_agent_tools", get_agent_tools_spy)
+    monkeypatch.setattr(registrar, "reset_agent_tools_cache", MagicMock())
+    monkeypatch.setattr(registrar, "get_human_tools", MagicMock())
+
+    definition = TOOL_DEFINITIONS["thenvoi_send_message"]
+    extended = _extend_with_chat_id(definition.input_model, None)
+
+    # Exercise the dispatch path directly: validation via AliasChoices
+    # resolves ``room_id`` to ``chat_id`` inside the extended input model.
+    from thenvoi_mcp.tools.registrar import _invoke
+
+    out = await _invoke(
+        surface="agent",
+        tool_name=definition.name,
+        method_name=definition.method_name,
+        input_model=extended,
+        pinned_room_id=None,
+        is_agent_room_bound=True,
+        is_human_room_bound=False,
+        ctx=MagicMock(),
+        kwargs={"content": "hi", "mentions": ["@x"], "room_id": "r_alias"},
+    )
+    get_agent_tools_spy.assert_called_once()
+    assert get_agent_tools_spy.call_args.args[1] == "r_alias"
+    assert "ok" in out
+
+
+async def test_validation_errors_report_fields() -> None:
+    definition = TOOL_DEFINITIONS["thenvoi_send_message"]
+    extended = _extend_with_chat_id(definition.input_model, None)
+
+    from thenvoi_mcp.tools.registrar import _invoke
+
+    with pytest.raises(ValueError, match="Invalid arguments") as exc_info:
+        await _invoke(
+            surface="agent",
+            tool_name=definition.name,
+            method_name=definition.method_name,
+            input_model=extended,
+            pinned_room_id=None,
+            is_agent_room_bound=True,
+            is_human_room_bound=False,
+            ctx=MagicMock(),
+            kwargs={"mentions": ["@x"], "room_id": "r_alias"},
+        )
+
+    assert "content" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Pinned agent handler: schema + dispatch
+# ---------------------------------------------------------------------------
+
+
+async def test_pinned_agent_schema_hides_chat_id() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["agent"], tools=[], agent_key="k", room_id="r_pinned")
+    register_tools(mcp, cfg)
+
+    t = await _list_tool(mcp, "thenvoi_send_message")
+    assert t is not None
+    props = t.inputSchema.get("properties", {})
+    assert "chat_id" not in props
+    assert "room_id" not in props
+
+
+async def test_pinned_agent_handler_injects_room_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_agent_tools = MagicMock()
+    fake_agent_tools.send_message = AsyncMock(return_value={"ok": True})
+    get_agent_tools_spy = MagicMock(return_value=fake_agent_tools)
+    monkeypatch.setattr(registrar, "get_agent_tools", get_agent_tools_spy)
+    monkeypatch.setattr(registrar, "reset_agent_tools_cache", MagicMock())
+    monkeypatch.setattr(registrar, "get_human_tools", MagicMock())
+
+    definition = TOOL_DEFINITIONS["thenvoi_send_message"]
+    pinned = _extend_with_chat_id(definition.input_model, "r_pinned")
+    handler = make_handler(
+        tool_name=definition.name,
+        surface="agent",
+        method_name=definition.method_name,
+        input_model=pinned,
+        pinned_room_id="r_pinned",
+        is_agent_room_bound=True,
+        is_human_room_bound=False,
+    )
+
+    ctx = MagicMock()
+    await handler(ctx=ctx, content="hi", mentions=["@x"])
+
+    get_agent_tools_spy.assert_called_once_with(ctx, "r_pinned")
+
+
+async def test_pinned_agent_handler_overrides_caller_chat_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_agent_tools = MagicMock()
+    fake_agent_tools.send_message = AsyncMock(return_value={"ok": True})
+    get_agent_tools_spy = MagicMock(return_value=fake_agent_tools)
+    monkeypatch.setattr(registrar, "get_agent_tools", get_agent_tools_spy)
+    monkeypatch.setattr(registrar, "reset_agent_tools_cache", MagicMock())
+    monkeypatch.setattr(registrar, "get_human_tools", MagicMock())
+
+    definition = TOOL_DEFINITIONS["thenvoi_send_message"]
+    pinned = _extend_with_chat_id(definition.input_model, "r_pinned")
+
+    from thenvoi_mcp.tools.registrar import _invoke
+
+    await _invoke(
+        surface="agent",
+        tool_name=definition.name,
+        method_name=definition.method_name,
+        input_model=pinned,
+        pinned_room_id="r_pinned",
+        is_agent_room_bound=True,
+        is_human_room_bound=False,
+        ctx=MagicMock(),
+        kwargs={"content": "hi", "mentions": ["@x"], "chat_id": "r_user"},
+    )
+
+    get_agent_tools_spy.assert_called_once()
+    assert get_agent_tools_spy.call_args.args[1] == "r_pinned"
+
+
+# ---------------------------------------------------------------------------
+# Human room-bound handler
+# ---------------------------------------------------------------------------
+
+
+async def test_unpinned_human_room_bound_advertises_chat_id() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["human"], tools=[], user_key="k")
+    register_tools(mcp, cfg)
+
+    t = await _list_tool(mcp, "thenvoi_send_my_chat_message")
+    assert t is not None
+    props = t.inputSchema.get("properties", {})
+    required = t.inputSchema.get("required", [])
+    assert "chat_id" in props
+    assert "chat_id" in required
+
+
+async def test_unpinned_human_handler_passes_chat_id_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_human_tools = MagicMock()
+    fake_human_tools.send_my_chat_message = AsyncMock(return_value={"ok": True})
+
+    monkeypatch.setattr(
+        registrar, "get_human_tools", MagicMock(return_value=fake_human_tools)
+    )
+    monkeypatch.setattr(registrar, "reset_agent_tools_cache", MagicMock())
+    monkeypatch.setattr(registrar, "get_agent_tools", MagicMock())
+
+    definition = TOOL_DEFINITIONS["thenvoi_send_my_chat_message"]
+    handler = make_handler(
+        tool_name=definition.name,
+        surface="human",
+        method_name=definition.method_name,
+        input_model=definition.input_model,
+        pinned_room_id=None,
+        is_agent_room_bound=False,
+        is_human_room_bound=True,
+    )
+
+    ctx = MagicMock()
+    await handler(ctx=ctx, chat_id="r1", content="hi", recipients="@bob")
+
+    call_kwargs = fake_human_tools.send_my_chat_message.await_args.kwargs
+    assert call_kwargs["chat_id"] == "r1"
+    assert call_kwargs["content"] == "hi"
+
+
+async def test_pinned_human_handler_injects_chat_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_human_tools = MagicMock()
+    fake_human_tools.send_my_chat_message = AsyncMock(return_value={"ok": True})
+
+    monkeypatch.setattr(
+        registrar, "get_human_tools", MagicMock(return_value=fake_human_tools)
+    )
+    monkeypatch.setattr(registrar, "reset_agent_tools_cache", MagicMock())
+    monkeypatch.setattr(registrar, "get_agent_tools", MagicMock())
+
+    definition = TOOL_DEFINITIONS["thenvoi_send_my_chat_message"]
+    pinned = _pin_existing_chat_id(definition.input_model, "r_pin")
+    handler = make_handler(
+        tool_name=definition.name,
+        surface="human",
+        method_name=definition.method_name,
+        input_model=pinned,
+        pinned_room_id="r_pin",
+        is_agent_room_bound=False,
+        is_human_room_bound=True,
+    )
+
+    ctx = MagicMock()
+    await handler(ctx=ctx, content="hi", recipients="@x")
+
+    call_kwargs = fake_human_tools.send_my_chat_message.await_args.kwargs
+    assert call_kwargs["chat_id"] == "r_pin"
+
+
+async def test_pinned_human_room_bound_schema_hides_chat_id() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["human"], tools=[], user_key="k", room_id="r_pin")
+    register_tools(mcp, cfg)
+
+    t = await _list_tool(mcp, "thenvoi_send_my_chat_message")
+    assert t is not None
+    assert "chat_id" not in t.inputSchema.get("properties", {})
+
+
+# ---------------------------------------------------------------------------
+# Room-less tools stay unchanged regardless of pin state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("pin", [None, "r_pin"])
+@pytest.mark.parametrize(
+    "tool_name",
+    ["thenvoi_list_my_chats", "thenvoi_get_my_profile"],
+)
+async def test_room_less_human_tools_schema_unchanged_by_pin(
+    pin: str | None, tool_name: str
+) -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["human"], tools=[], user_key="k", room_id=pin)
+    register_tools(mcp, cfg)
+
+    t = await _list_tool(mcp, tool_name)
+    assert t is not None
+    props = t.inputSchema.get("properties", {})
+    # These tools have no chat_id in their underlying input model.
+    assert "chat_id" not in props
+
+
+async def test_room_less_list_my_contacts_unchanged_by_pin() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["human"],
+        tools=["contacts"],
+        user_key="k",
+        room_id="r_pin",
+    )
+    register_tools(mcp, cfg)
+
+    t = await _list_tool(mcp, "thenvoi_list_my_contacts")
+    assert t is not None
+    assert "chat_id" not in t.inputSchema.get("properties", {})
+
+
+# ---------------------------------------------------------------------------
+# reset_agent_tools_cache is called at start of each invocation
+# ---------------------------------------------------------------------------
+
+
+async def test_reset_agent_tools_cache_called_on_every_invocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_agent_tools = MagicMock()
+    fake_agent_tools.send_message = AsyncMock(return_value={"ok": True})
+
+    reset_spy = MagicMock()
+    monkeypatch.setattr(registrar, "reset_agent_tools_cache", reset_spy)
+    monkeypatch.setattr(
+        registrar, "get_agent_tools", MagicMock(return_value=fake_agent_tools)
+    )
+    monkeypatch.setattr(registrar, "get_human_tools", MagicMock())
+
+    definition = TOOL_DEFINITIONS["thenvoi_send_message"]
+    extended = _extend_with_chat_id(definition.input_model, None)
+    handler = make_handler(
+        tool_name=definition.name,
+        surface="agent",
+        method_name=definition.method_name,
+        input_model=extended,
+        pinned_room_id=None,
+        is_agent_room_bound=True,
+        is_human_room_bound=False,
+    )
+
+    ctx = MagicMock()
+    await handler(ctx=ctx, content="a", mentions=["@x"], chat_id="r1")
+    await handler(ctx=ctx, content="b", mentions=["@x"], chat_id="r1")
+
+    assert reset_spy.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Old handler coexistence — legacy handwritten handler names do not collide
+# ---------------------------------------------------------------------------
+
+
+def test_new_tool_names_are_prefixed_no_collision_with_legacy() -> None:
+    # SDK names are all prefixed. Legacy handwritten handler names are not
+    # (e.g. ``list_my_contacts``, ``get_my_chat``). Any collision would have
+    # FastMCP warn & keep the first registration.
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["agent", "human"],
+        tools=["contacts", "memory"],
+        agent_key="a",
+        user_key="u",
+    )
+    register_tools(mcp, cfg)
+
+    for name in _registered_names(mcp):
+        assert name.startswith("thenvoi_"), name

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,0 +1,213 @@
+"""Unit tests for `thenvoi_mcp.server`.
+
+Focused on the pieces of `run()` that do non-trivial branching without
+actually starting FastMCP: the pure-legacy escape-hatch detection and its
+scope write-back (C2/I3 from INT-350 PR review).
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from thenvoi_mcp import server as server_mod
+from thenvoi_mcp.config import Config
+
+
+# ---------------------------------------------------------------------------
+# _is_pure_legacy_invocation
+# ---------------------------------------------------------------------------
+
+
+def _make_args(**overrides: object) -> argparse.Namespace:
+    """Build an argparse.Namespace matching server.parse_args() defaults."""
+    defaults: dict[str, object] = {
+        "user_key": None,
+        "agent_key": None,
+        "room_id": None,
+        "scope": None,
+        "tools": None,
+        "transport": None,
+        "host": None,
+        "port": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def test_is_pure_legacy_invocation_true_when_only_legacy_key(monkeypatch):
+    monkeypatch.delenv("THENVOI_USER_KEY", raising=False)
+    monkeypatch.delenv("THENVOI_AGENT_KEY", raising=False)
+    monkeypatch.delenv("BAND_USER_KEY", raising=False)
+    monkeypatch.delenv("BAND_AGENT_KEY", raising=False)
+    monkeypatch.delenv("THENVOI_MCP_SCOPE", raising=False)
+    monkeypatch.delenv("BAND_MCP_SCOPE", raising=False)
+    monkeypatch.delenv("THENVOI_MCP_TOOLS", raising=False)
+    monkeypatch.delenv("BAND_MCP_TOOLS", raising=False)
+    monkeypatch.delenv("THENVOI_MCP_ROOM_ID", raising=False)
+    monkeypatch.delenv("BAND_MCP_ROOM_ID", raising=False)
+
+    config = Config(legacy_key="thnv_u_abc", scope=[])
+    args = _make_args()
+    assert server_mod._is_pure_legacy_invocation(args, config) is True
+
+
+def test_is_pure_legacy_invocation_false_when_cli_scope_set(monkeypatch):
+    for name in (
+        "THENVOI_USER_KEY",
+        "THENVOI_AGENT_KEY",
+        "BAND_USER_KEY",
+        "BAND_AGENT_KEY",
+        "THENVOI_MCP_SCOPE",
+        "BAND_MCP_SCOPE",
+        "THENVOI_MCP_TOOLS",
+        "BAND_MCP_TOOLS",
+        "THENVOI_MCP_ROOM_ID",
+        "BAND_MCP_ROOM_ID",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    config = Config(legacy_key="thnv_u_abc", scope=[])
+    args = _make_args(scope=["agent"])
+    assert server_mod._is_pure_legacy_invocation(args, config) is False
+
+
+def test_is_pure_legacy_invocation_false_when_new_env_set(monkeypatch):
+    for name in (
+        "THENVOI_USER_KEY",
+        "THENVOI_AGENT_KEY",
+        "BAND_USER_KEY",
+        "BAND_AGENT_KEY",
+        "THENVOI_MCP_SCOPE",
+        "BAND_MCP_SCOPE",
+        "THENVOI_MCP_TOOLS",
+        "BAND_MCP_TOOLS",
+        "THENVOI_MCP_ROOM_ID",
+        "BAND_MCP_ROOM_ID",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("THENVOI_USER_KEY", "thnv_u_explicit")
+
+    config = Config(legacy_key="thnv_abc", scope=[])
+    args = _make_args()
+    assert server_mod._is_pure_legacy_invocation(args, config) is False
+
+
+def test_is_pure_legacy_invocation_false_when_no_legacy_key():
+    config = Config(legacy_key=None, scope=[])
+    args = _make_args()
+    assert server_mod._is_pure_legacy_invocation(args, config) is False
+
+
+# ---------------------------------------------------------------------------
+# Escape-hatch scope write-back (C2 / I3)
+#
+# These tests exercise the `validate(config)` failure path inside `run()` by
+# driving the relevant branch directly rather than invoking `run()` — `run()`
+# ends with `mcp.run()` which would block on stdio. The logic under test is
+# small enough to reconstruct inline: if `_is_pure_legacy_invocation` is true,
+# the legacy key's prefix determines `config.scope`.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "legacy_key,expected_scope",
+    [
+        ("thnv_u_timestamp_random", ["human"]),
+        ("thnv_a_timestamp_random", ["agent"]),
+        ("thnv_timestamp_random", ["agent", "human"]),
+    ],
+)
+def test_escape_hatch_writes_scope_from_legacy_key(
+    monkeypatch, legacy_key, expected_scope
+):
+    """When the escape hatch fires, config.scope is rewritten to match what
+    the legacy key can actually serve.
+
+    Applies whether or not validate() raised — an all-capable `thnv_*` key
+    passes validate with default scope ["agent"] but still needs write-back so
+    the surface loaded matches what AppContext.scope advertises downstream.
+    """
+    for name in (
+        "THENVOI_USER_KEY",
+        "THENVOI_AGENT_KEY",
+        "BAND_USER_KEY",
+        "BAND_AGENT_KEY",
+        "THENVOI_MCP_SCOPE",
+        "BAND_MCP_SCOPE",
+        "THENVOI_MCP_TOOLS",
+        "BAND_MCP_TOOLS",
+        "THENVOI_MCP_ROOM_ID",
+        "BAND_MCP_ROOM_ID",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("THENVOI_API_KEY", legacy_key)
+
+    from thenvoi_mcp.config import (
+        ConfigError,
+        _legacy_key_capabilities,
+        resolve_config,
+        validate,
+    )
+
+    args = _make_args()
+    cli = {
+        "user_key": args.user_key,
+        "agent_key": args.agent_key,
+        "room_id": args.room_id,
+        "scope": args.scope,
+        "tools": args.tools,
+    }
+    # Replay the relevant branch of run(): resolve, try validate, apply
+    # scope write-back on every pure-legacy invocation.
+    import os
+
+    config = resolve_config(cli=cli, env=os.environ)
+
+    try:
+        validate(config)
+    except ConfigError:
+        pass  # pure-legacy invocation keeps booting
+
+    assert server_mod._is_pure_legacy_invocation(args, config) is True
+    legacy_human, legacy_agent = _legacy_key_capabilities(config.legacy_key)
+    scope_writeback: list[str] = []
+    if legacy_agent:
+        scope_writeback.append("agent")
+    if legacy_human:
+        scope_writeback.append("human")
+    config.scope = scope_writeback  # type: ignore[assignment]
+
+    assert config.scope == expected_scope
+
+
+def test_escape_hatch_user_legacy_key_maps_to_human_only(monkeypatch):
+    """Specific C2 scenario from the review: `THENVOI_API_KEY=thnv_u_*` must
+    log / register as `['human']`, not `['agent']`.
+    """
+    for name in (
+        "THENVOI_USER_KEY",
+        "THENVOI_AGENT_KEY",
+        "BAND_USER_KEY",
+        "BAND_AGENT_KEY",
+        "THENVOI_MCP_SCOPE",
+        "BAND_MCP_SCOPE",
+        "THENVOI_MCP_TOOLS",
+        "BAND_MCP_TOOLS",
+        "THENVOI_MCP_ROOM_ID",
+        "BAND_MCP_ROOM_ID",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("THENVOI_API_KEY", "thnv_u_xyz")
+
+    from thenvoi_mcp.config import _legacy_key_capabilities
+
+    legacy_human, legacy_agent = _legacy_key_capabilities("thnv_u_xyz")
+    assert legacy_human is True
+    assert legacy_agent is False
+
+    # And the server-side _choose_legacy_key_type resolves to "user" when
+    # scope is later set to ["human"].
+    config = Config(legacy_key="thnv_u_xyz", scope=["human"])
+    assert server_mod._choose_legacy_key_type(config) == "user"

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -103,11 +103,9 @@ def test_is_pure_legacy_invocation_false_when_no_legacy_key():
 # ---------------------------------------------------------------------------
 # Escape-hatch scope write-back (C2 / I3)
 #
-# These tests exercise the `validate(config)` failure path inside `run()` by
-# driving the relevant branch directly rather than invoking `run()` — `run()`
-# ends with `mcp.run()` which would block on stdio. The logic under test is
-# small enough to reconstruct inline: if `_is_pure_legacy_invocation` is true,
-# the legacy key's prefix determines `config.scope`.
+# These tests exercise the helper used by the `validate(config)` failure path
+# inside `run()` rather than invoking `run()` itself — `run()` ends with
+# `mcp.run()` which would block on stdio.
 # ---------------------------------------------------------------------------
 
 
@@ -144,12 +142,7 @@ def test_escape_hatch_writes_scope_from_legacy_key(
         monkeypatch.delenv(name, raising=False)
     monkeypatch.setenv("THENVOI_API_KEY", legacy_key)
 
-    from thenvoi_mcp.config import (
-        ConfigError,
-        _legacy_key_capabilities,
-        resolve_config,
-        validate,
-    )
+    from thenvoi_mcp.config import ConfigError, resolve_config, validate
 
     args = _make_args()
     cli = {
@@ -171,19 +164,14 @@ def test_escape_hatch_writes_scope_from_legacy_key(
         pass  # pure-legacy invocation keeps booting
 
     assert server_mod._is_pure_legacy_invocation(args, config) is True
-    legacy_human, legacy_agent = _legacy_key_capabilities(config.legacy_key)
-    scope_writeback: list[str] = []
-    if legacy_agent:
-        scope_writeback.append("agent")
-    if legacy_human:
-        scope_writeback.append("human")
-    config.scope = scope_writeback  # type: ignore[assignment]
+    rewritten = server_mod._apply_legacy_scope_writeback(config)
 
-    assert config.scope == expected_scope
+    assert rewritten.scope == expected_scope
+    assert rewritten is not config
 
 
 def test_escape_hatch_user_legacy_key_maps_to_human_only(monkeypatch):
-    """Specific C2 scenario from the review: `THENVOI_API_KEY=thnv_u_*` must
+    """Specific C2 scenario from the review: user legacy keys must
     log / register as `['human']`, not `['agent']`.
     """
     for name in (
@@ -210,4 +198,29 @@ def test_escape_hatch_user_legacy_key_maps_to_human_only(monkeypatch):
     # And the server-side _choose_legacy_key_type resolves to "user" when
     # scope is later set to ["human"].
     config = Config(legacy_key="thnv_u_xyz", scope=["human"])
+    assert server_mod._choose_legacy_key_type(config) == "user"
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        ("thnv_u_xyz", "user"),
+        ("band_u_xyz", "user"),
+        ("thnv_a_xyz", "agent"),
+        ("band_a_xyz", "agent"),
+        ("thnv_xyz", "legacy"),
+        ("band_xyz", "legacy"),
+    ],
+)
+def test_get_key_type_accepts_thenvoi_and_band_prefixes(key, expected):
+    assert server_mod.get_key_type(key) == expected
+
+
+def test_scope_specific_key_type_wins_over_stale_legacy_key():
+    config = Config(
+        user_key="thnv_u_current",
+        legacy_key="thnv_a_stale",
+        scope=["human"],
+    )
+
     assert server_mod._choose_legacy_key_type(config) == "user"

--- a/tests/unit/test_shared.py
+++ b/tests/unit/test_shared.py
@@ -67,10 +67,10 @@ def test_get_agent_tools_caches_per_room(monkeypatch):
     app_ctx = AppContext(client=fake_client, agent_rest=fake_agent_rest)
     ctx = _make_ctx(app_ctx)
 
-    constructed: list[str] = []
+    constructed: list[str | None] = []
 
     class FakeAgentTools:
-        def __init__(self, room_id: str, rest: object):
+        def __init__(self, room_id: str | None, rest: object):
             self.room_id = room_id
             self.rest = rest
             constructed.append(room_id)
@@ -90,7 +90,7 @@ def test_get_agent_tools_returns_distinct_instance_per_room(monkeypatch):
     ctx = _make_ctx(app_ctx)
 
     class FakeAgentTools:
-        def __init__(self, room_id: str, rest: object):
+        def __init__(self, room_id: str | None, rest: object):
             self.room_id = room_id
 
     monkeypatch.setattr(shared_mod, "_try_import_agent_tools", lambda: FakeAgentTools)
@@ -102,6 +102,24 @@ def test_get_agent_tools_returns_distinct_instance_per_room(monkeypatch):
     assert b.room_id == "room_B"
 
 
+def test_get_agent_tools_accepts_none_for_room_less_agent_tools(monkeypatch):
+    fake_client = MagicMock()
+    fake_agent_rest = MagicMock()
+    app_ctx = AppContext(client=fake_client, agent_rest=fake_agent_rest)
+    ctx = _make_ctx(app_ctx)
+
+    class FakeAgentTools:
+        def __init__(self, room_id: str | None, rest: object):
+            self.room_id = room_id
+
+    monkeypatch.setattr(shared_mod, "_try_import_agent_tools", lambda: FakeAgentTools)
+
+    result = get_agent_tools(ctx, None)
+
+    assert result.room_id is None
+    assert app_ctx._agent_tools_cache == {None: result}
+
+
 def test_reset_agent_tools_cache_clears_entries(monkeypatch):
     fake_client = MagicMock()
     fake_agent_rest = MagicMock()
@@ -109,7 +127,7 @@ def test_reset_agent_tools_cache_clears_entries(monkeypatch):
     ctx = _make_ctx(app_ctx)
 
     class FakeAgentTools:
-        def __init__(self, room_id: str, rest: object):
+        def __init__(self, room_id: str | None, rest: object):
             self.room_id = room_id
 
     monkeypatch.setattr(shared_mod, "_try_import_agent_tools", lambda: FakeAgentTools)

--- a/tests/unit/test_shared.py
+++ b/tests/unit/test_shared.py
@@ -9,8 +9,11 @@ fails.
 from __future__ import annotations
 
 import logging
+from typing import Any
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import pytest
 
 from thenvoi_mcp import shared as shared_mod
 from thenvoi_mcp.shared import (
@@ -21,10 +24,17 @@ from thenvoi_mcp.shared import (
 )
 
 
-def _make_ctx(app_context: AppContext) -> object:
+def _make_ctx(app_context: AppContext) -> Any:
     """Build a minimal ctx object matching AppContextType for the helpers."""
     request_context = SimpleNamespace(lifespan_context=app_context)
     return SimpleNamespace(request_context=request_context)
+
+
+@pytest.fixture(autouse=True)
+def reset_agent_tools_context_cache():
+    shared_mod._agent_tools_cache_var.set({})
+    yield
+    shared_mod._agent_tools_cache_var.set({})
 
 
 # ---------------------------------------------------------------------------
@@ -117,7 +127,7 @@ def test_get_agent_tools_accepts_none_for_room_less_agent_tools(monkeypatch):
     result = get_agent_tools(ctx, None)
 
     assert result.room_id is None
-    assert app_ctx._agent_tools_cache == {None: result}
+    assert get_agent_tools(ctx, None) is result
 
 
 def test_reset_agent_tools_cache_clears_entries(monkeypatch):
@@ -133,10 +143,9 @@ def test_reset_agent_tools_cache_clears_entries(monkeypatch):
     monkeypatch.setattr(shared_mod, "_try_import_agent_tools", lambda: FakeAgentTools)
 
     before = get_agent_tools(ctx, "room_A")
-    assert app_ctx._agent_tools_cache == {"room_A": before}
+    assert get_agent_tools(ctx, "room_A") is before
 
     reset_agent_tools_cache(ctx)
-    assert app_ctx._agent_tools_cache == {}
 
     # A subsequent call produces a fresh instance.
     after = get_agent_tools(ctx, "room_A")
@@ -167,4 +176,4 @@ def test_get_agent_tools_returns_none_when_sdk_import_fails(monkeypatch, caplog)
     result = get_agent_tools(ctx, "room_A")
     assert result is None
     # Nothing should be cached when construction fails.
-    assert app_ctx._agent_tools_cache == {}
+    assert get_agent_tools(ctx, "room_A") is None

--- a/tests/unit/test_shared.py
+++ b/tests/unit/test_shared.py
@@ -1,0 +1,152 @@
+"""Unit tests for `thenvoi_mcp.shared`.
+
+Covers acceptance criterion #11 from INT-350: `get_human_tools` returns a
+singleton, `get_agent_tools` caches per-room, `reset_agent_tools_cache` clears
+the cache, and both helpers fail-soft (log + return None) when the SDK import
+fails.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from thenvoi_mcp import shared as shared_mod
+from thenvoi_mcp.shared import (
+    AppContext,
+    get_agent_tools,
+    get_human_tools,
+    reset_agent_tools_cache,
+)
+
+
+def _make_ctx(app_context: AppContext) -> object:
+    """Build a minimal ctx object matching AppContextType for the helpers."""
+    request_context = SimpleNamespace(lifespan_context=app_context)
+    return SimpleNamespace(request_context=request_context)
+
+
+# ---------------------------------------------------------------------------
+# get_human_tools: startup-constructed singleton
+# ---------------------------------------------------------------------------
+
+
+def test_get_human_tools_returns_singleton_across_calls():
+    sentinel = object()
+    fake_client = MagicMock()
+    app_ctx = AppContext(client=fake_client, human_tools=sentinel)
+    ctx = _make_ctx(app_ctx)
+
+    first = get_human_tools(ctx)
+    second = get_human_tools(ctx)
+    assert first is sentinel
+    assert second is sentinel
+    assert first is second
+
+
+def test_get_human_tools_returns_none_and_warns_when_unavailable(caplog):
+    fake_client = MagicMock()
+    app_ctx = AppContext(client=fake_client, human_tools=None)
+    ctx = _make_ctx(app_ctx)
+
+    with caplog.at_level(logging.WARNING, logger="thenvoi_mcp.shared"):
+        result = get_human_tools(ctx)
+    assert result is None
+    assert any("HumanTools not available" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# get_agent_tools: per-room cache
+# ---------------------------------------------------------------------------
+
+
+def test_get_agent_tools_caches_per_room(monkeypatch):
+    fake_client = MagicMock()
+    fake_agent_rest = MagicMock()
+    app_ctx = AppContext(client=fake_client, agent_rest=fake_agent_rest)
+    ctx = _make_ctx(app_ctx)
+
+    constructed: list[str] = []
+
+    class FakeAgentTools:
+        def __init__(self, room_id: str, rest: object):
+            self.room_id = room_id
+            self.rest = rest
+            constructed.append(room_id)
+
+    monkeypatch.setattr(shared_mod, "_try_import_agent_tools", lambda: FakeAgentTools)
+
+    first = get_agent_tools(ctx, "room_A")
+    second = get_agent_tools(ctx, "room_A")
+    assert first is second
+    assert constructed == ["room_A"]
+
+
+def test_get_agent_tools_returns_distinct_instance_per_room(monkeypatch):
+    fake_client = MagicMock()
+    fake_agent_rest = MagicMock()
+    app_ctx = AppContext(client=fake_client, agent_rest=fake_agent_rest)
+    ctx = _make_ctx(app_ctx)
+
+    class FakeAgentTools:
+        def __init__(self, room_id: str, rest: object):
+            self.room_id = room_id
+
+    monkeypatch.setattr(shared_mod, "_try_import_agent_tools", lambda: FakeAgentTools)
+
+    a = get_agent_tools(ctx, "room_A")
+    b = get_agent_tools(ctx, "room_B")
+    assert a is not b
+    assert a.room_id == "room_A"
+    assert b.room_id == "room_B"
+
+
+def test_reset_agent_tools_cache_clears_entries(monkeypatch):
+    fake_client = MagicMock()
+    fake_agent_rest = MagicMock()
+    app_ctx = AppContext(client=fake_client, agent_rest=fake_agent_rest)
+    ctx = _make_ctx(app_ctx)
+
+    class FakeAgentTools:
+        def __init__(self, room_id: str, rest: object):
+            self.room_id = room_id
+
+    monkeypatch.setattr(shared_mod, "_try_import_agent_tools", lambda: FakeAgentTools)
+
+    before = get_agent_tools(ctx, "room_A")
+    assert app_ctx._agent_tools_cache == {"room_A": before}
+
+    reset_agent_tools_cache(ctx)
+    assert app_ctx._agent_tools_cache == {}
+
+    # A subsequent call produces a fresh instance.
+    after = get_agent_tools(ctx, "room_A")
+    assert after is not before
+
+
+def test_get_agent_tools_returns_none_without_agent_credential(caplog):
+    fake_client = MagicMock()
+    app_ctx = AppContext(client=fake_client, agent_rest=None)
+    ctx = _make_ctx(app_ctx)
+
+    with caplog.at_level(logging.WARNING, logger="thenvoi_mcp.shared"):
+        result = get_agent_tools(ctx, "room_A")
+    assert result is None
+    assert any("no agent credential configured" in r.message for r in caplog.records)
+
+
+def test_get_agent_tools_returns_none_when_sdk_import_fails(monkeypatch, caplog):
+    fake_client = MagicMock()
+    fake_agent_rest = MagicMock()
+    app_ctx = AppContext(client=fake_client, agent_rest=fake_agent_rest)
+    ctx = _make_ctx(app_ctx)
+
+    # Simulate INT-349 not yet merged: the SDK import inside
+    # _try_import_agent_tools fails and the helper returns None.
+    monkeypatch.setattr(shared_mod, "_try_import_agent_tools", lambda: None)
+
+    result = get_agent_tools(ctx, "room_A")
+    assert result is None
+    # Nothing should be cached when construction fails.
+    assert app_ctx._agent_tools_cache == {}

--- a/tests/unit/test_shared.py
+++ b/tests/unit/test_shared.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from thenvoi_mcp import shared as shared_mod
+from thenvoi_mcp.config import Config
 from thenvoi_mcp.shared import (
     AppContext,
     get_agent_tools,
@@ -177,3 +178,88 @@ def test_get_agent_tools_returns_none_when_sdk_import_fails(monkeypatch, caplog)
     assert result is None
     # Nothing should be cached when construction fails.
     assert get_agent_tools(ctx, "room_A") is None
+
+
+# ---------------------------------------------------------------------------
+# Legacy sync-client credential selection
+# ---------------------------------------------------------------------------
+
+
+def test_build_app_context_uses_user_key_for_human_scope_with_stale_legacy_agent_key(
+    monkeypatch,
+):
+    constructed: list[str] = []
+
+    class FakeRestClient:
+        def __init__(self, *, api_key: str, base_url: str):
+            constructed.append(api_key)
+            self.api_key = api_key
+            self.base_url = base_url
+
+    monkeypatch.setattr(shared_mod, "RestClient", FakeRestClient)
+    monkeypatch.setattr(shared_mod, "AsyncRestClient", MagicMock())
+    monkeypatch.setattr(shared_mod, "_try_import_human_tools", lambda: None)
+
+    app_ctx = shared_mod.build_app_context(
+        Config(
+            user_key="thnv_u_current",
+            legacy_key="thnv_a_stale",
+            scope=["human"],
+        )
+    )
+
+    assert constructed == ["thnv_u_current"]
+    assert app_ctx.client.api_key == "thnv_u_current"
+
+
+def test_build_app_context_uses_agent_key_for_agent_scope_with_stale_legacy_user_key(
+    monkeypatch,
+):
+    constructed: list[str] = []
+
+    class FakeRestClient:
+        def __init__(self, *, api_key: str, base_url: str):
+            constructed.append(api_key)
+            self.api_key = api_key
+            self.base_url = base_url
+
+    monkeypatch.setattr(shared_mod, "RestClient", FakeRestClient)
+    monkeypatch.setattr(shared_mod, "AsyncRestClient", MagicMock())
+    monkeypatch.setattr(shared_mod, "_try_import_human_tools", lambda: None)
+
+    app_ctx = shared_mod.build_app_context(
+        Config(
+            agent_key="thnv_a_current",
+            legacy_key="thnv_u_stale",
+            scope=["agent"],
+        )
+    )
+
+    assert constructed == ["thnv_a_current"]
+    assert app_ctx.client.api_key == "thnv_a_current"
+
+
+def test_build_app_context_keeps_all_capable_legacy_key_for_dual_scope(monkeypatch):
+    constructed: list[str] = []
+
+    class FakeRestClient:
+        def __init__(self, *, api_key: str, base_url: str):
+            constructed.append(api_key)
+            self.api_key = api_key
+            self.base_url = base_url
+
+    monkeypatch.setattr(shared_mod, "RestClient", FakeRestClient)
+    monkeypatch.setattr(shared_mod, "AsyncRestClient", MagicMock())
+    monkeypatch.setattr(shared_mod, "_try_import_human_tools", lambda: None)
+
+    app_ctx = shared_mod.build_app_context(
+        Config(
+            user_key="thnv_u_current",
+            agent_key="thnv_a_current",
+            legacy_key="thnv_legacy_all",
+            scope=["agent", "human"],
+        )
+    )
+
+    assert constructed == ["thnv_legacy_all"]
+    assert app_ctx.client.api_key == "thnv_legacy_all"

--- a/uv.lock
+++ b/uv.lock
@@ -1830,7 +1830,7 @@ wheels = [
 
 [[package]]
 name = "thenvoi-mcp"
-version = "1.1.1"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary

Phase 2 of INT-338: replace the single-key + prefix-inference config with explicit dual credentials, new `--scope` / `--tools` / `--room-id` CLI flags, and typo suggestions. Legacy `THENVOI_API_KEY` path preserved.

Closes INT-350. Part of INT-338.

## Changes

- **`src/thenvoi_mcp/config.py`** — rewritten. `Config` dataclass (`user_key`, `agent_key`, `room_id`, `scope`, `tools`, `legacy_key`, `warnings`), `resolve_config(cli, env)` with per-slot precedence (CLI > `THENVOI_*` > `BAND_*` > `THENVOI_API_KEY`), `validate(config)` fails fast on missing credentials, `ConfigWarning` frozen dataclass (`kind` + `value` + `did_you_mean` + `message`), private `_suggest_value` wrapping `difflib.get_close_matches(..., n=1, cutoff=0.6)`. `Config.scope` / `Config.tools` defaults now honor ticket AC #6 (`scope=["agent"]`, `tools=[]`) so instances built directly via `Config(user_key="x")` match `resolve_config({}, {})`.
- **`src/thenvoi_mcp/shared.py`** — `AppContext` now holds `human_rest` / `agent_rest` (`AsyncRestClient`), the `human_tools` singleton, `pinned_room_id`, and resolved `scope` / `tools`. `get_human_tools(ctx)` returns the startup-constructed singleton; `get_agent_tools(ctx, room_id)` builds a room-scoped `AgentTools` and caches per `room_id` within a request. Legacy sync `client` is still populated during the transition so handwritten tools keep working until Phase 4.
- **`src/thenvoi_mcp/server.py`** — adds `--user-key`, `--agent-key`, `--room-id`, `--scope`, `--tools` flags; emits `config.warnings` at WARN before traffic starts; fail-fast via `validate()`, with a `_is_pure_legacy_invocation` escape hatch so an unmodified `THENVOI_API_KEY` setup keeps booting. On the legacy path `config.scope` is now rewritten from `_legacy_key_capabilities(config.legacy_key)` so startup logs and `AppContext.scope` match the surface that actually loads.
- **`README.md`** + **`mcp_config_example.json`** — new env vars, new CLI examples, legacy `THENVOI_API_KEY` block labelled "still supported," explicit note that operators who relied on implicit contacts tools must now pass `--tools contacts`.
- **Tests** — `tests/unit/test_config.py` (47 cases covering precedence, aliasing, cross-slot masking, warnings, validate), new `tests/unit/test_server.py` (escape-hatch detection + scope write-back for each legacy-key prefix), new `tests/unit/test_shared.py` (singleton / per-room cache / reset / SDK import fail-soft).

## Review fixes (this revision)

- **Rebased onto current `origin/dev`.** The earlier push was branched from `origin/develop` before PR #98 renamed the default branch, which surfaced as a stale 30-line `CHANGELOG.md` delete in the diff. `git diff origin/dev..HEAD -- CHANGELOG.md` is now empty; Phase 2 carries no CHANGELOG changes (breaking-change note lands in Phase 4's entry per the ticket).
- **Escape-hatch writes scope back into config (C2 / I3).** Previously `THENVOI_API_KEY=thnv_u_xxx` alone would log `Resolved scope: ['agent']` while loading human tools. Now the legacy key's prefix drives `config.scope`: `thnv_u_*` -> `["human"]`, `thnv_a_*` -> `["agent"]`, unprefixed `thnv_*` -> `["agent", "human"]`. Phase 3's registrar reads `AppContext.scope` to pick a surface, so this write-back is required for INT-351.
- **`Config.scope` default (I1).** `field(default_factory=lambda: cast("list[Scope]", list(DEFAULT_SCOPE)))`; pyrefly happy, tests guard against mutable-default sharing.
- **Removed dead `_split_csv` wrapper (I6).** It did `list(values)` on an already-list; `_normalize_list_value` in `config.py` does the real CSV work.
- **Cross-phase TODOs.** `AppContext.client` marked `TODO(INT-352)`; `_agent_tools_cache` and `reset_agent_tools_cache` marked `TODO(INT-351)`. See "For INT-351" below.
- **`shared.py` coverage.** 42% -> 64% via new `tests/unit/test_shared.py`.

## Testing

- `uv run pytest tests/unit/ -v` — 64 passed.
- `uv run pytest tests/ --ignore=tests/integration -v` — 215 passed, 84.51% coverage.
- `uv run pre-commit run --all-files` — clean (ruff, ruff-format, pyrefly, gitleaks).
- Smoke tests:
  - `THENVOI_USER_KEY=thnv_u_xxx uv run thenvoi-mcp --scope human --help` — clean help output.
  - `THENVOI_AGENT_KEY=thnv_a_xxx uv run thenvoi-mcp --scope agent --tools contact` — `WARNING ... unknown --tools value 'contact' — did you mean 'contacts'? ignoring.` fires before server start.
  - `THENVOI_API_KEY=thnv_u_xxx uv run thenvoi-mcp` — logs `API key type: user` and `Resolved scope: ['human']` (C2 fix verified). Same for `thnv_a_*` -> `['agent']` and `thnv_*` -> `['agent', 'human']`.

## Notes for reviewers

- **`HumanTools` coordination with INT-349.** The SDK's `HumanTools` / `AgentTools` classes land in Phase 1 (INT-349) and are not yet installed in this environment. `_try_import_human_tools` / `_try_import_agent_tools` in `shared.py` catch `ImportError` and return `None`; the `get_*` helpers log a structured WARN when the SDK isn't installed. This keeps Phase 2 mergeable ahead of Phase 1.
- **Default `--tools []` is a deliberate break.** Contacts tools are no longer default-on. CHANGELOG entry lands in Phase 4 (INT-352) alongside the deletion of the duplicated handwritten handlers.
- **`--room-id` resolution lands here; field-stripping + injection is INT-351.** `config.pinned_room_id` is on `AppContext`, but the registrar that inspects `input_model.model_fields` and swaps in `SkipJsonSchema` lands in INT-351.
- **`AppContext.client` kept non-optional.** Handwritten tools all do `get_app_context(ctx).client.<namespace>`. Marked `TODO(INT-352)` for Phase 4's deletion.

## For INT-351 (Phase 3)

- `get_human_tools(ctx)` returns the singleton or `None`; `get_agent_tools(ctx, room_id)` returns a per-room instance cached on `AppContext._agent_tools_cache`.
- **Call `reset_agent_tools_cache(ctx)` at the start of each tool invocation.** The cache is plumbed in Phase 2 but has no caller; without the Phase 3 wiring it would leak across tool calls for the server's lifetime. See the `TODO(INT-351)` on `_agent_tools_cache` in `shared.py`.
- **`AppContext.scope` is now authoritative.** For legacy-key operators the escape hatch writes `config.scope` back from the key's capabilities before it's stored on `AppContext`, so the registrar can drive surface selection off `AppContext.scope` without re-inferring from keys.