### PR TITLE
feat: SDK-driven MCP tool registrar (INT-351)

### DIFF
--- a/src/thenvoi_mcp/server.py
+++ b/src/thenvoi_mcp/server.py
@@ -32,6 +32,7 @@ from thenvoi_mcp.shared import (
     mcp,
     set_pending_config,
 )
+from thenvoi_mcp.tools.registrar import register_tools
 
 
 def get_key_type(key: str) -> str:
@@ -301,6 +302,14 @@ def run() -> None:
     else:
         key_type = get_key_type(settings.thenvoi_api_key)
     load_tools(key_type)
+
+    # Phase 3 (INT-351): SDK-driven registrar. Registers every
+    # ``iter_tool_definitions(surface=s, ...)`` entry for each scope in
+    # ``config.scope``. SDK tool names are ``thenvoi_``-prefixed and do not
+    # collide with the legacy handwritten handler names above — both surfaces
+    # coexist during the Phase 3 → Phase 4 transition. Phase 4 (INT-352)
+    # deletes ``load_tools`` and the handwritten handlers.
+    register_tools(mcp, config)
 
     # Determine transport mode (CLI args override env vars)
     transport: Literal["stdio", "sse"] = args.transport or settings.transport

--- a/src/thenvoi_mcp/shared.py
+++ b/src/thenvoi_mcp/shared.py
@@ -81,11 +81,12 @@ class AppContext:
     scope: list[str] = field(default_factory=list)
     tools: list[str] = field(default_factory=list)
 
-    # Per-request cache for AgentTools keyed by room_id. The registrar clears
-    # this at the start of each tool call; see `get_agent_tools`.
+    # Per-request cache for AgentTools keyed by room_id. Room-less agent tools
+    # use None as the cache key. The registrar clears this at the start of each
+    # tool call; see `get_agent_tools`.
     # TODO(INT-351): call reset_agent_tools_cache(ctx) at the start of each
     # tool invocation. Phase 2 plumbs the cache; Phase 3 owns the reset site.
-    _agent_tools_cache: dict[str, Any] = field(default_factory=dict)
+    _agent_tools_cache: dict[str | None, Any] = field(default_factory=dict)
 
 
 AppContextType = Context[ServerSession, AppContext, None]
@@ -255,14 +256,15 @@ def get_human_tools(ctx: AppContextType) -> Any:
     return app_ctx.human_tools
 
 
-def get_agent_tools(ctx: AppContextType, room_id: str) -> Any:
+def get_agent_tools(ctx: AppContextType, room_id: str | None) -> Any:
     """Return an `AgentTools` instance scoped to `room_id`.
 
     Per-request cache: Phase 3 can call this multiple times in the same tool
     invocation (participant-resolution paths walk back to the room) and must
     not construct twice. The registrar is responsible for clearing the cache
     at the start of each request; within a single call, repeated
-    `get_agent_tools(ctx, "r1")` returns the same object.
+    `get_agent_tools(ctx, "r1")` returns the same object. Room-less agent tools
+    pass None through to AgentTools.
 
     Returns None when the SDK isn't installed or when no agent credential is
     configured.

--- a/src/thenvoi_mcp/tools/registrar.py
+++ b/src/thenvoi_mcp/tools/registrar.py
@@ -1,0 +1,475 @@
+"""SDK-driven MCP tool registrar (Phase 3 of INT-338, INT-351).
+
+Replaces the handwritten per-tool ``@mcp.tool()`` registrations with a
+scope-filtered loop over ``thenvoi.runtime.tools.iter_tool_definitions(...)``.
+Each handler is a closure that:
+
+1. Resets the per-request AgentTools cache on ``AppContext``.
+2. Resolves the room id from validated input (or injects ``pinned_room_id``).
+3. Dispatches to the Phase-1 ``HumanTools`` / ``AgentTools`` SDK method.
+
+Design deviation from the Phase 3 spec (resolved with the ticket author)
+-----------------------------------------------------------------------
+The spec originally told the registrar to classify agent tools by checking
+for a ``room_id`` field on ``ToolDefinition.input_model.model_fields``. That
+classifier does not work for agent tools, because ``AgentTools`` is *room-
+scoped via its constructor* (``AgentTools(room_id=..., rest=...)``) — the
+SDK input models only cover method arguments, not the construction-time
+room id. Putting ``room_id`` on the SDK input model would create a mismatch
+between the input schema and the underlying ``AgentTools`` method
+signature.
+
+Resolution: the registrar *itself* is the layer that adds a room field to
+the advertised agent tool schema. Today's handwritten MCP handlers use
+``chat_id`` on every room-bound agent tool (see
+``tools/agent/agent_messages.py`` and friends) — keeping that name means
+zero breaking change for existing MCP consumers. ``AliasChoices("chat_id",
+"room_id")`` makes the forward-compat ``room_id`` name work too, matching
+the Phase 3 spec's intent. See ``AGENT_ROOM_BOUND_TOOL_NAMES`` below.
+
+Human-surface classification is unchanged: human input models already carry
+a ``chat_id`` field where applicable (Phase 1 derived them from
+``HumanTools`` method signatures), so the Phase 3 spec's
+``model_fields``-based classifier works for the human surface.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from typing import Annotated, Any, Callable
+
+from mcp.server.fastmcp import FastMCP
+from pydantic import AliasChoices, BaseModel, Field, create_model
+from pydantic.fields import FieldInfo
+from pydantic.json_schema import SkipJsonSchema
+
+from thenvoi_mcp.config import Config
+from thenvoi_mcp.shared import (
+    AppContextType,
+    get_agent_tools,
+    get_human_tools,
+    logger,
+    reset_agent_tools_cache,
+)
+
+# ---------------------------------------------------------------------------
+# Agent room-bound tools
+# ---------------------------------------------------------------------------
+#
+# These are the agent tools whose *current* MCP handler in
+# ``src/thenvoi_mcp/tools/agent/*.py`` takes ``chat_id`` as a kwarg (i.e. the
+# handler is room-scoped). Because ``AgentTools`` is constructor-scoped, the
+# Phase 1 SDK input models do not carry a room field — so the registrar has
+# to re-add it at the transport layer.
+#
+# Derived by grepping today's agent handlers for ``chat_id``. Kept as a
+# module-level constant so tests can assert on it and so Phase 4 (INT-352)
+# has an obvious pivot point for the handwritten-handler deletion.
+AGENT_ROOM_BOUND_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "thenvoi_send_message",
+        "thenvoi_send_event",
+        "thenvoi_add_participant",
+        "thenvoi_remove_participant",
+        "thenvoi_get_participants",
+        "thenvoi_lookup_peers",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Input-model transformers
+# ---------------------------------------------------------------------------
+
+
+def _extend_with_chat_id(
+    original: type[BaseModel],
+    pinned_room_id: str | None,
+) -> type[BaseModel]:
+    """Return a subclass of ``original`` that ADDS a ``chat_id`` field.
+
+    Applied to agent room-bound tools (the SDK input models do not carry a
+    room field; see module docstring).
+
+    - Unpinned: ``chat_id`` is a required ``str`` with
+      ``validation_alias=AliasChoices("chat_id", "room_id")`` so callers can
+      post either name.
+    - Pinned: ``chat_id`` is ``SkipJsonSchema[str | None]`` defaulted to
+      ``None`` — the field is hidden from the advertised JSON schema but
+      still accepted by the validator if a client sends it. The handler
+      injects ``pinned_room_id`` at call time.
+    """
+    if pinned_room_id is None:
+        return create_model(  # type: ignore[call-overload]
+            f"{original.__name__}WithChatId",
+            __base__=original,
+            chat_id=(
+                str,
+                Field(
+                    ...,
+                    validation_alias=AliasChoices("chat_id", "room_id"),
+                    description=(
+                        "ID of the chat room (accepted as 'chat_id' or 'room_id')."
+                    ),
+                ),
+            ),
+        )
+    return create_model(  # type: ignore[call-overload]
+        f"{original.__name__}WithChatIdPinned",
+        __base__=original,
+        chat_id=(
+            SkipJsonSchema[str | None],
+            Field(
+                default=None,
+                validation_alias=AliasChoices("chat_id", "room_id"),
+                description=("Pinned room id (hidden from advertised schema)."),
+            ),
+        ),
+    )
+
+
+def _pin_existing_chat_id(
+    original: type[BaseModel],
+    pinned_room_id: str,  # noqa: ARG001 - injected at call time, not in model
+) -> type[BaseModel]:
+    """Return a subclass that re-annotates existing ``chat_id`` as pinned.
+
+    Applied to human room-bound tools (the SDK input models already have
+    ``chat_id``). The advertised schema omits the field; inbound values are
+    still accepted via alias so an older client passing ``chat_id`` does not
+    fail validation. The handler injects ``pinned_room_id`` at call time.
+    """
+    return create_model(  # type: ignore[call-overload]
+        f"{original.__name__}Pinned",
+        __base__=original,
+        chat_id=(
+            SkipJsonSchema[str | None],
+            Field(
+                default=None,
+                validation_alias=AliasChoices("chat_id", "room_id"),
+                description=("Pinned room id (hidden from advertised schema)."),
+            ),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Handler construction
+# ---------------------------------------------------------------------------
+
+
+def _build_handler_signature(
+    ctx_param_name: str,
+    input_model: type[BaseModel],
+) -> inspect.Signature:
+    """Build a ``inspect.Signature`` for the dynamic handler.
+
+    FastMCP inspects the handler's signature to derive the advertised JSON
+    schema (see ``fastmcp.utilities.func_metadata.func_metadata``). We
+    therefore need a real signature with one parameter per
+    ``input_model`` field (plus the ``Context`` parameter FastMCP auto-
+    injects).
+
+    Fields annotated as ``SkipJsonSchema[...]`` are intentionally omitted:
+    they are pinned-mode fields whose value is injected at call time and
+    MUST NOT appear in the advertised schema.
+
+    ``validation_alias`` (e.g. ``AliasChoices("chat_id", "room_id")``) is
+    propagated onto the parameter annotation so FastMCP's internally-
+    generated arg model accepts alternate names at the wire.
+    """
+    ctx_param = inspect.Parameter(
+        ctx_param_name,
+        kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        annotation=AppContextType,
+    )
+
+    parameters: list[inspect.Parameter] = [ctx_param]
+    for field_name, field_info in input_model.model_fields.items():
+        if _is_skip_json_schema(field_info):
+            continue
+        base_ann = field_info.annotation if field_info.annotation is not None else Any
+
+        # Copy ``validation_alias`` onto the synthesized parameter so
+        # FastMCP's derived arg model accepts both chat_id and room_id.
+        field_kwargs: dict[str, Any] = {}
+        if field_info.validation_alias is not None:
+            field_kwargs["validation_alias"] = field_info.validation_alias
+        if field_info.description:
+            field_kwargs["description"] = field_info.description
+
+        annotation = base_ann
+        if field_kwargs:
+            annotation = Annotated[base_ann, Field(**field_kwargs)]
+
+        if field_info.is_required():
+            parameters.append(
+                inspect.Parameter(
+                    field_name,
+                    kind=inspect.Parameter.KEYWORD_ONLY,
+                    annotation=annotation,
+                )
+            )
+        else:
+            default = field_info.default
+            parameters.append(
+                inspect.Parameter(
+                    field_name,
+                    kind=inspect.Parameter.KEYWORD_ONLY,
+                    annotation=annotation,
+                    default=default,
+                )
+            )
+
+    return inspect.Signature(parameters=parameters, return_annotation=str)
+
+
+def _is_skip_json_schema(field_info: FieldInfo) -> bool:
+    """Return True if ``field_info.annotation`` is ``SkipJsonSchema[...]``."""
+    metadata = getattr(field_info, "metadata", None) or []
+    for meta in metadata:
+        if meta.__class__.__name__ == "SkipJsonSchema":
+            return True
+    # Fallback: also inspect the annotation repr for the SkipJsonSchema marker
+    # (older pydantic versions store it differently).
+    ann_repr = repr(field_info.annotation)
+    return "SkipJsonSchema" in ann_repr
+
+
+def _serialize(result: Any) -> str:
+    """Serialize SDK method output to a JSON string for MCP wire transport."""
+    if result is None:
+        return json.dumps(None)
+    if isinstance(result, str):
+        return result
+    if hasattr(result, "model_dump"):
+        return json.dumps(result.model_dump(mode="json"), default=str, indent=2)
+    if isinstance(result, list):
+        out = []
+        for item in result:
+            if hasattr(item, "model_dump"):
+                out.append(item.model_dump(mode="json"))
+            else:
+                out.append(item)
+        return json.dumps(out, default=str, indent=2)
+    return json.dumps(result, default=str, indent=2)
+
+
+async def _invoke(
+    *,
+    surface: str,
+    tool_name: str,
+    method_name: str,
+    input_model: type[BaseModel],
+    pinned_room_id: str | None,
+    is_agent_room_bound: bool,
+    is_human_room_bound: bool,
+    ctx: AppContextType,
+    kwargs: dict[str, Any],
+) -> str:
+    """The actual async dispatch body shared by every generated handler."""
+    reset_agent_tools_cache(ctx)
+
+    # Inject pinned room id BEFORE validation so the input model's chat_id
+    # field is populated from the pin even though it is hidden from the
+    # advertised schema.
+    if pinned_room_id is not None and (is_agent_room_bound or is_human_room_bound):
+        kwargs.setdefault("chat_id", pinned_room_id)
+
+    try:
+        validated = input_model.model_validate(kwargs)
+    except Exception as exc:
+        raise ValueError(f"Invalid arguments for {tool_name}: {exc}") from exc
+
+    call_kwargs = validated.model_dump(exclude_none=True, by_alias=False)
+
+    if surface == "agent":
+        # Agent tools: pull chat_id out of kwargs and scope AgentTools to it.
+        if is_agent_room_bound:
+            chat_id = call_kwargs.pop("chat_id", None)
+            if not chat_id:
+                raise ValueError(
+                    f"{tool_name}: missing chat_id (or room_id) for room-bound tool"
+                )
+            tools_instance = get_agent_tools(ctx, chat_id)
+        else:
+            # Room-less agent tool (e.g. ``thenvoi_create_chatroom``). The
+            # SDK's ``AgentTools`` is constructor-scoped, but such tools
+            # only touch ``self.rest`` — we can safely construct with the
+            # pinned room id (or an empty placeholder if none is set) and
+            # dispatch.
+            tools_instance = get_agent_tools(ctx, pinned_room_id or "")
+    else:
+        tools_instance = get_human_tools(ctx)
+
+    if tools_instance is None:
+        raise RuntimeError(
+            f"{tool_name}: {surface} tools not available (SDK not installed or "
+            "no credential configured for this scope)"
+        )
+
+    method = getattr(tools_instance, method_name, None)
+    if method is None or not callable(method):
+        raise RuntimeError(
+            f"{tool_name}: method '{method_name}' not found on "
+            f"{type(tools_instance).__name__}"
+        )
+
+    result = method(**call_kwargs)
+    if inspect.isawaitable(result):
+        result = await result
+
+    return _serialize(result)
+
+
+def make_handler(
+    *,
+    tool_name: str,
+    surface: str,
+    method_name: str,
+    input_model: type[BaseModel],
+    pinned_room_id: str | None,
+    is_agent_room_bound: bool,
+    is_human_room_bound: bool,
+) -> Callable[..., Any]:
+    """Return a dynamically-signatured async handler for ``mcp.add_tool``.
+
+    FastMCP inspects ``__signature__`` / real parameters to build the tool's
+    advertised JSON schema. We therefore synthesize a function whose
+    parameter list matches the (post-extension, post-pin) input model's
+    visible fields.
+    """
+    ctx_param_name = "ctx"
+
+    async def _dispatch(**kwargs: Any) -> str:
+        ctx = kwargs.pop(ctx_param_name)
+        return await _invoke(
+            surface=surface,
+            tool_name=tool_name,
+            method_name=method_name,
+            input_model=input_model,
+            pinned_room_id=pinned_room_id,
+            is_agent_room_bound=is_agent_room_bound,
+            is_human_room_bound=is_human_room_bound,
+            ctx=ctx,
+            kwargs=kwargs,
+        )
+
+    sig = _build_handler_signature(ctx_param_name, input_model)
+    _dispatch.__signature__ = sig  # type: ignore[attr-defined]
+    _dispatch.__name__ = tool_name
+    # Description comes from the SDK input model's docstring (Phase 1 sets
+    # these to the LLM-facing tool description).
+    _dispatch.__doc__ = (input_model.__doc__ or "").strip() or f"Execute {tool_name}"
+
+    # Build an Annotated annotation map for FastMCP's get_type_hints() call.
+    # We can't rely on forward-referenced types since the model is dynamic,
+    # so we stamp __annotations__ directly.
+    annotations: dict[str, Any] = {ctx_param_name: AppContextType}
+    for param in sig.parameters.values():
+        if param.name == ctx_param_name:
+            continue
+        annotations[param.name] = param.annotation
+    annotations["return"] = str
+    _dispatch.__annotations__ = annotations
+
+    return _dispatch
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def _classify_tool(
+    definition: Any,  # ToolDefinition
+) -> tuple[bool, bool]:
+    """Return (is_agent_room_bound, is_human_room_bound) for a definition.
+
+    Agent tools use the hard-coded ``AGENT_ROOM_BOUND_TOOL_NAMES`` set
+    because the SDK input models don't carry a room field (see module
+    docstring).
+
+    Human tools are classified by inspecting ``input_model.model_fields``
+    for ``chat_id`` — the Phase 1 human models carry it where applicable.
+    """
+    if definition.surface == "agent":
+        return (definition.name in AGENT_ROOM_BOUND_TOOL_NAMES, False)
+    if definition.surface == "human":
+        has_chat_id = "chat_id" in definition.input_model.model_fields
+        return (False, has_chat_id)
+    return (False, False)
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+
+def register_tools(mcp: FastMCP, config: Config) -> None:
+    """Register every SDK-defined tool for the scopes in ``config.scope``.
+
+    Delegates to ``iter_tool_definitions(surface=..., include_contacts=...,
+    include_memory=...)`` for the source of truth on which tools are
+    available, and translates each ``ToolDefinition`` into a FastMCP tool
+    registration with an appropriate input schema (extended with chat_id
+    for agent room-bound tools, schema-hidden pinned for pinned-mode
+    room-bound tools on either surface).
+
+    Safe to call after the handwritten ``tools.agent.*`` / ``tools.human.*``
+    modules have been imported: SDK tool names are ``thenvoi_``-prefixed
+    and do not collide with the legacy handwritten handler names.
+    """
+    try:
+        from thenvoi.runtime.tools import iter_tool_definitions
+    except Exception as exc:  # pragma: no cover - import-time guard
+        logger.warning(
+            "register_tools(): Thenvoi SDK not available — skipping SDK-driven "
+            "tool registration. Legacy handwritten handlers will still serve "
+            "traffic. (%s)",
+            exc,
+        )
+        return
+
+    include_contacts = "contacts" in config.tools
+    include_memory = "memory" in config.tools
+    pinned_room_id = config.room_id
+
+    total = 0
+    for surface in config.scope:
+        definitions = iter_tool_definitions(
+            surface=surface,
+            include_contacts=include_contacts,
+            include_memory=include_memory,
+        )
+        for definition in definitions:
+            is_agent_room_bound, is_human_room_bound = _classify_tool(definition)
+
+            # Build the per-tool input model (original, extended, or pinned).
+            model: type[BaseModel] = definition.input_model
+            if is_agent_room_bound:
+                model = _extend_with_chat_id(model, pinned_room_id)
+            elif is_human_room_bound and pinned_room_id is not None:
+                model = _pin_existing_chat_id(model, pinned_room_id)
+
+            handler = make_handler(
+                tool_name=definition.name,
+                surface=definition.surface,
+                method_name=definition.method_name,
+                input_model=model,
+                pinned_room_id=pinned_room_id,
+                is_agent_room_bound=is_agent_room_bound,
+                is_human_room_bound=is_human_room_bound,
+            )
+            mcp.add_tool(handler, name=definition.name)
+            total += 1
+
+    logger.info("SDK-driven registrar: registered %d tools", total)
+
+
+__all__ = [
+    "AGENT_ROOM_BOUND_TOOL_NAMES",
+    "make_handler",
+    "register_tools",
+]

--- a/src/thenvoi_mcp/tools/registrar.py
+++ b/src/thenvoi_mcp/tools/registrar.py
@@ -40,7 +40,7 @@ import json
 from typing import Annotated, Any, Callable
 
 from mcp.server.fastmcp import FastMCP
-from pydantic import AliasChoices, BaseModel, Field, create_model
+from pydantic import AliasChoices, BaseModel, Field, ValidationError, create_model
 from pydantic.fields import FieldInfo
 from pydantic.json_schema import SkipJsonSchema
 
@@ -275,12 +275,15 @@ async def _invoke(
     # field is populated from the pin even though it is hidden from the
     # advertised schema.
     if pinned_room_id is not None and (is_agent_room_bound or is_human_room_bound):
-        kwargs.setdefault("chat_id", pinned_room_id)
+        kwargs["chat_id"] = pinned_room_id
 
     try:
         validated = input_model.model_validate(kwargs)
-    except Exception as exc:
-        raise ValueError(f"Invalid arguments for {tool_name}: {exc}") from exc
+    except ValidationError as exc:
+        errors = "; ".join(
+            f"{err['loc'][0]}: {err['msg']}" for err in exc.errors()
+        )
+        raise ValueError(f"Invalid arguments for {tool_name}: {errors}") from exc
 
     call_kwargs = validated.model_dump(exclude_none=True, by_alias=False)
 
@@ -294,17 +297,12 @@ async def _invoke(
                 )
             tools_instance = get_agent_tools(ctx, chat_id)
         else:
-            # Room-less agent tool (e.g. ``thenvoi_create_chatroom``). The
-            # SDK's ``AgentTools`` is constructor-scoped, but such tools
-            # only touch ``self.rest`` — we can safely construct with the
-            # pinned room id (or an empty placeholder if none is set) and
-            # dispatch.
-            tools_instance = get_agent_tools(ctx, pinned_room_id or "")
+            tools_instance = get_agent_tools(ctx, pinned_room_id)
     else:
         tools_instance = get_human_tools(ctx)
 
     if tools_instance is None:
-        raise RuntimeError(
+        raise ValueError(
             f"{tool_name}: {surface} tools not available (SDK not installed or "
             "no credential configured for this scope)"
         )

--- a/tests/integration/test_forwarding.py
+++ b/tests/integration/test_forwarding.py
@@ -1,0 +1,295 @@
+"""Integration tests for the SDK-driven MCP registrar (INT-351, Phase 3).
+
+Covers the acceptance criteria enumerated in INT-351: CLI flag combinations
+(``--scope``, ``--tools``, ``--room-id``) produce the expected advertised
+tool surface and the expected dispatch behavior when a tool is called.
+
+Drives the FastMCP server in-process via ``mcp._tool_manager.call_tool`` to
+exercise the full registration + validation + dispatch path without
+requiring an actual stdio subprocess. This is deliberate: today's
+integration suite already spawns subprocesses via ``@requires_api``, but
+those tests hit a live API. Phase 3 needs to verify the transport wiring
+itself, which a live server can't distinguish from legacy handlers. A
+lightweight in-process test gives us that signal, and the existing
+``@requires_api`` smoke tests catch remaining live-API regressions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from thenvoi_mcp.config import Config
+from thenvoi_mcp.tools import registrar
+from thenvoi_mcp.tools.registrar import register_tools
+
+
+@dataclass
+class _FakeAppCtx:
+    """Stand-in for ``AppContext`` for in-process dispatch tests."""
+
+    human_tools: Any = None
+    agent_tools_by_room: dict[str, Any] | None = None
+    _cache_reset_count: int = 0
+
+    def __post_init__(self) -> None:
+        if self.agent_tools_by_room is None:
+            self.agent_tools_by_room = {}
+
+
+class _FakeCtx:
+    """Stand-in for ``AppContextType`` (the FastMCP Context wrapper)."""
+
+    def __init__(self, app_ctx: _FakeAppCtx) -> None:
+        self.request_context = MagicMock()
+        self.request_context.lifespan_context = app_ctx
+
+
+@pytest.fixture(autouse=True)
+def _patch_tool_resolvers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect ``get_*_tools`` / cache reset to the ``_FakeAppCtx`` payload.
+
+    We can't use a real ``AppContext`` here because that would require a
+    live REST client. The fake app ctx holds pre-built MagicMock instances.
+    """
+
+    def fake_get_human_tools(ctx: Any) -> Any:
+        app = ctx.request_context.lifespan_context
+        return app.human_tools
+
+    def fake_get_agent_tools(ctx: Any, room_id: str) -> Any:
+        app = ctx.request_context.lifespan_context
+        return app.agent_tools_by_room.get(room_id) or app.agent_tools_by_room.get("*")
+
+    def fake_reset(ctx: Any) -> None:
+        app = ctx.request_context.lifespan_context
+        app._cache_reset_count += 1
+
+    monkeypatch.setattr(registrar, "get_human_tools", fake_get_human_tools)
+    monkeypatch.setattr(registrar, "get_agent_tools", fake_get_agent_tools)
+    monkeypatch.setattr(registrar, "reset_agent_tools_cache", fake_reset)
+
+
+# ---------------------------------------------------------------------------
+# --scope agent,human (no --tools, no --room-id)
+# ---------------------------------------------------------------------------
+
+
+async def test_scope_agent_human_no_tools_registers_both_surfaces_without_contacts() -> (
+    None
+):
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["agent", "human"],
+        tools=[],
+        agent_key="a",
+        user_key="u",
+    )
+    register_tools(mcp, cfg)
+
+    names = {t.name for t in await mcp.list_tools()}
+    # Agent surface present
+    assert "thenvoi_send_message" in names
+    # Human surface present
+    assert "thenvoi_send_my_chat_message" in names
+    # Contacts not present by default
+    assert "thenvoi_list_my_contacts" not in names
+    assert "thenvoi_list_contacts" not in names
+
+
+async def test_scope_agent_human_tools_contacts_exposes_resolve_handle() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["agent", "human"],
+        tools=["contacts"],
+        agent_key="a",
+        user_key="u",
+    )
+    register_tools(mcp, cfg)
+    names = {t.name for t in await mcp.list_tools()}
+
+    assert "thenvoi_resolve_handle" in names
+    assert "thenvoi_list_my_contacts" in names
+    assert "thenvoi_list_contacts" in names
+
+
+async def test_scope_agent_human_tools_memory_exposes_memory_tools() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["agent", "human"],
+        tools=["memory"],
+        agent_key="a",
+        user_key="u",
+    )
+    register_tools(mcp, cfg)
+    names = {t.name for t in await mcp.list_tools()}
+
+    assert "thenvoi_list_user_memories" in names
+    assert "thenvoi_store_memory" in names
+
+
+async def test_scope_agent_human_tools_contacts_memory_exposes_both() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["agent", "human"],
+        tools=["contacts", "memory"],
+        agent_key="a",
+        user_key="u",
+    )
+    register_tools(mcp, cfg)
+    names = {t.name for t in await mcp.list_tools()}
+
+    assert "thenvoi_list_my_contacts" in names
+    assert "thenvoi_list_user_memories" in names
+
+
+# ---------------------------------------------------------------------------
+# --scope human only
+# ---------------------------------------------------------------------------
+
+
+async def test_scope_human_only_does_not_register_agent_tools() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["human"], tools=[], user_key="u")
+    register_tools(mcp, cfg)
+    names = {t.name for t in await mcp.list_tools()}
+
+    # Human tools present
+    assert "thenvoi_list_my_chats" in names
+    # Agent tools absent
+    assert "thenvoi_send_message" not in names
+    assert "thenvoi_get_participants" not in names
+
+
+async def test_call_agent_tool_in_human_only_scope_is_unknown() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["human"], tools=[], user_key="u")
+    register_tools(mcp, cfg)
+
+    # FastMCP surfaces unknown tools as ToolError("Unknown tool: ...").
+    with pytest.raises(Exception) as excinfo:
+        await mcp._tool_manager.call_tool("thenvoi_send_message", {})
+    assert "Unknown tool" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# --room-id r_pinned: schema strips chat_id/room_id; pin is injected
+# ---------------------------------------------------------------------------
+
+
+async def test_pinned_mode_agent_send_message_dispatches_to_pinned_room() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["agent"], tools=[], agent_key="a", room_id="r_pinned")
+    register_tools(mcp, cfg)
+
+    # Schema should NOT advertise chat_id or room_id
+    tool = next(t for t in await mcp.list_tools() if t.name == "thenvoi_send_message")
+    props = tool.inputSchema.get("properties", {})
+    assert "chat_id" not in props
+    assert "room_id" not in props
+
+    # Dispatch with NO chat_id → pinned room is used.
+    agent_tools = MagicMock()
+    agent_tools.send_message = AsyncMock(return_value={"ok": True})
+    app_ctx = _FakeAppCtx(agent_tools_by_room={"r_pinned": agent_tools})
+
+    result = await mcp._tool_manager.call_tool(
+        "thenvoi_send_message",
+        {"content": "hi", "mentions": ["@bob"]},
+        context=_FakeCtx(app_ctx),
+    )
+    agent_tools.send_message.assert_awaited_once()
+    call_kwargs = agent_tools.send_message.await_args.kwargs
+    assert "chat_id" not in call_kwargs  # stripped before method call
+    # Reset called once for this invocation.
+    assert app_ctx._cache_reset_count == 1
+    # Result serialized to JSON
+    assert "ok" in str(result)
+
+
+async def test_pinned_mode_human_send_message_dispatches_with_pinned_chat_id() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["human"], tools=[], user_key="u", room_id="r_pinned")
+    register_tools(mcp, cfg)
+
+    tool = next(
+        t for t in await mcp.list_tools() if t.name == "thenvoi_send_my_chat_message"
+    )
+    props = tool.inputSchema.get("properties", {})
+    assert "chat_id" not in props
+
+    human_tools = MagicMock()
+    human_tools.send_my_chat_message = AsyncMock(return_value={"ok": True})
+    app_ctx = _FakeAppCtx(human_tools=human_tools)
+
+    result = await mcp._tool_manager.call_tool(
+        "thenvoi_send_my_chat_message",
+        {"content": "hi", "recipients": "@bob"},
+        context=_FakeCtx(app_ctx),
+    )
+    call_kwargs = human_tools.send_my_chat_message.await_args.kwargs
+    assert call_kwargs["chat_id"] == "r_pinned"  # pin injected
+    assert "ok" in str(result)
+
+
+async def test_pinned_mode_room_less_human_tool_unchanged() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["human"], tools=[], user_key="u", room_id="r_pinned")
+    register_tools(mcp, cfg)
+
+    tool = next(t for t in await mcp.list_tools() if t.name == "thenvoi_list_my_chats")
+    props = tool.inputSchema.get("properties", {})
+    assert "chat_id" not in props  # it was never there to begin with
+    # Tool still listed and callable.
+    human_tools = MagicMock()
+    human_tools.list_my_chats = AsyncMock(return_value={"data": []})
+    app_ctx = _FakeAppCtx(human_tools=human_tools)
+
+    await mcp._tool_manager.call_tool(
+        "thenvoi_list_my_chats", {}, context=_FakeCtx(app_ctx)
+    )
+    human_tools.list_my_chats.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Unpinned dispatch: chat_id and room_id both route to the same room
+# ---------------------------------------------------------------------------
+
+
+async def test_unpinned_agent_dispatch_via_chat_id() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["agent"], tools=[], agent_key="a")
+    register_tools(mcp, cfg)
+
+    agent_tools = MagicMock()
+    agent_tools.send_message = AsyncMock(return_value={"id": "msg_1"})
+    app_ctx = _FakeAppCtx(agent_tools_by_room={"r_abc": agent_tools})
+
+    await mcp._tool_manager.call_tool(
+        "thenvoi_send_message",
+        {"content": "hi", "mentions": ["@bob"], "chat_id": "r_abc"},
+        context=_FakeCtx(app_ctx),
+    )
+    agent_tools.send_message.assert_awaited_once()
+
+
+async def test_unpinned_agent_dispatch_via_room_id_alias() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["agent"], tools=[], agent_key="a")
+    register_tools(mcp, cfg)
+
+    agent_tools = MagicMock()
+    agent_tools.send_message = AsyncMock(return_value={"id": "msg_1"})
+    app_ctx = _FakeAppCtx(agent_tools_by_room={"r_xyz": agent_tools})
+
+    # Client sends "room_id" — the alias routes to chat_id internally.
+    await mcp._tool_manager.call_tool(
+        "thenvoi_send_message",
+        {"content": "hi", "mentions": ["@bob"], "room_id": "r_xyz"},
+        context=_FakeCtx(app_ctx),
+    )
+    agent_tools.send_message.assert_awaited_once()

--- a/tests/unit/test_registrar.py
+++ b/tests/unit/test_registrar.py
@@ -1,0 +1,548 @@
+"""Unit tests for ``thenvoi_mcp.tools.registrar``.
+
+Covers Phase 3 (INT-351) acceptance criteria:
+- Scope-filtered registration matches ``iter_tool_definitions(surface=...)``.
+- ``--tools contacts`` / ``--tools memory`` flow into ``iter_tool_definitions``.
+- Agent room-bound tools get a ``chat_id`` field added to the advertised schema.
+- ``AliasChoices("chat_id", "room_id")`` accepts both names inbound.
+- Pinned mode hides ``chat_id`` from advertised schema for both surfaces.
+- Handler invokes ``get_agent_tools(ctx, chat_id)`` / ``get_human_tools(ctx)``.
+- Handler strips ``chat_id`` from kwargs before calling ``AgentTools.<method>``.
+- Handler re-calls ``reset_agent_tools_cache(ctx)`` at the start of each invocation.
+- Room-less tools are registered unchanged regardless of pin state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from thenvoi.runtime.tools import (  # type: ignore[import-not-found]
+    TOOL_DEFINITIONS,
+    iter_tool_definitions,
+)
+from thenvoi_mcp.config import Config
+from thenvoi_mcp.tools import registrar
+from thenvoi_mcp.tools.registrar import (
+    AGENT_ROOM_BOUND_TOOL_NAMES,
+    _classify_tool,
+    _extend_with_chat_id,
+    _pin_existing_chat_id,
+    make_handler,
+    register_tools,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _registered_names(mcp: FastMCP) -> set[str]:
+    tools = asyncio.new_event_loop().run_until_complete(mcp.list_tools())
+    return {t.name for t in tools}
+
+
+async def _list_tool(mcp: FastMCP, name: str) -> Any:
+    tools = await mcp.list_tools()
+    for t in tools:
+        if t.name == name:
+            return t
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Scope filtering
+# ---------------------------------------------------------------------------
+
+
+def test_scope_agent_only_registers_agent_surface() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["agent"], tools=[], agent_key="k")
+    register_tools(mcp, cfg)
+
+    expected = {
+        d.name
+        for d in iter_tool_definitions(
+            surface="agent", include_contacts=False, include_memory=False
+        )
+    }
+    assert _registered_names(mcp) == expected
+
+
+def test_scope_human_only_registers_human_surface() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["human"], tools=[], user_key="k")
+    register_tools(mcp, cfg)
+
+    expected = {
+        d.name
+        for d in iter_tool_definitions(
+            surface="human", include_contacts=False, include_memory=False
+        )
+    }
+    assert _registered_names(mcp) == expected
+
+
+def test_scope_both_registers_union() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["agent", "human"], tools=[], agent_key="a", user_key="u")
+    register_tools(mcp, cfg)
+
+    expected = set()
+    for s in ("agent", "human"):
+        expected |= {
+            d.name
+            for d in iter_tool_definitions(
+                surface=s, include_contacts=False, include_memory=False
+            )
+        }
+    assert _registered_names(mcp) == expected
+
+
+# ---------------------------------------------------------------------------
+# --tools contacts / --tools memory propagation
+# ---------------------------------------------------------------------------
+
+
+def test_tools_contacts_registers_contact_tools() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["agent", "human"],
+        tools=["contacts"],
+        agent_key="a",
+        user_key="u",
+    )
+    register_tools(mcp, cfg)
+    names = _registered_names(mcp)
+
+    assert "thenvoi_list_my_contacts" in names
+    assert "thenvoi_resolve_handle" in names
+    # Memory stays off
+    assert "thenvoi_list_memories" not in names
+    assert "thenvoi_list_user_memories" not in names
+
+
+def test_tools_memory_registers_memory_tools() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["agent", "human"],
+        tools=["memory"],
+        agent_key="a",
+        user_key="u",
+    )
+    register_tools(mcp, cfg)
+    names = _registered_names(mcp)
+
+    assert "thenvoi_list_memories" in names
+    assert "thenvoi_list_user_memories" in names
+    # Contacts stay off
+    assert "thenvoi_list_my_contacts" not in names
+
+
+def test_tools_both_registers_both_groups() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["agent", "human"],
+        tools=["contacts", "memory"],
+        agent_key="a",
+        user_key="u",
+    )
+    register_tools(mcp, cfg)
+    names = _registered_names(mcp)
+
+    assert "thenvoi_list_my_contacts" in names
+    assert "thenvoi_list_memories" in names
+
+
+def test_tools_empty_disables_both() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["agent", "human"],
+        tools=[],
+        agent_key="a",
+        user_key="u",
+    )
+    register_tools(mcp, cfg)
+    names = _registered_names(mcp)
+
+    assert "thenvoi_list_memories" not in names
+    assert "thenvoi_list_user_memories" not in names
+    assert "thenvoi_list_my_contacts" not in names
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def test_agent_room_bound_constant_matches_classifier() -> None:
+    for name in AGENT_ROOM_BOUND_TOOL_NAMES:
+        definition = TOOL_DEFINITIONS[name]
+        is_agent, is_human = _classify_tool(definition)
+        assert is_agent is True
+        assert is_human is False
+
+
+def test_agent_room_less_tool_not_classified_room_bound() -> None:
+    # thenvoi_create_chatroom does not take a room id on the agent surface.
+    definition = TOOL_DEFINITIONS["thenvoi_create_chatroom"]
+    is_agent, is_human = _classify_tool(definition)
+    assert is_agent is False
+    assert is_human is False
+
+
+def test_human_chat_id_tool_classified_room_bound() -> None:
+    definition = TOOL_DEFINITIONS["thenvoi_send_my_chat_message"]
+    is_agent, is_human = _classify_tool(definition)
+    assert is_agent is False
+    assert is_human is True
+
+
+def test_human_room_less_tool_not_classified_room_bound() -> None:
+    definition = TOOL_DEFINITIONS["thenvoi_list_my_chats"]
+    is_agent, is_human = _classify_tool(definition)
+    assert is_agent is False
+    assert is_human is False
+
+
+# ---------------------------------------------------------------------------
+# Unpinned agent handler: schema + dispatch
+# ---------------------------------------------------------------------------
+
+
+async def test_unpinned_agent_schema_includes_chat_id() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["agent"], tools=[], agent_key="k")
+    register_tools(mcp, cfg)
+
+    t = await _list_tool(mcp, "thenvoi_send_message")
+    assert t is not None
+    props = t.inputSchema.get("properties", {})
+    required = t.inputSchema.get("required", [])
+    assert "chat_id" in props
+    assert "chat_id" in required
+    # Room-less agent tool: no chat_id in schema.
+    cr = await _list_tool(mcp, "thenvoi_create_chatroom")
+    assert cr is not None
+    assert "chat_id" not in cr.inputSchema.get("properties", {})
+
+
+def test_agent_room_bound_model_accepts_room_id_alias() -> None:
+    definition = TOOL_DEFINITIONS["thenvoi_send_message"]
+    extended = _extend_with_chat_id(definition.input_model, None)
+    v1 = extended.model_validate({"content": "hi", "mentions": ["@x"], "room_id": "r1"})
+    assert v1.chat_id == "r1"
+    v2 = extended.model_validate({"content": "hi", "mentions": ["@x"], "chat_id": "r2"})
+    assert v2.chat_id == "r2"
+
+
+async def test_unpinned_agent_handler_calls_get_agent_tools_with_chat_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Fake AgentTools method
+    fake_agent_tools = MagicMock()
+    fake_agent_tools.send_message = AsyncMock(return_value={"ok": True})
+
+    get_agent_tools_spy = MagicMock(return_value=fake_agent_tools)
+    reset_spy = MagicMock()
+
+    monkeypatch.setattr(registrar, "get_agent_tools", get_agent_tools_spy)
+    monkeypatch.setattr(registrar, "reset_agent_tools_cache", reset_spy)
+    monkeypatch.setattr(registrar, "get_human_tools", MagicMock())
+
+    definition = TOOL_DEFINITIONS["thenvoi_send_message"]
+    extended = _extend_with_chat_id(definition.input_model, None)
+
+    handler = make_handler(
+        tool_name=definition.name,
+        surface="agent",
+        method_name=definition.method_name,
+        input_model=extended,
+        pinned_room_id=None,
+        is_agent_room_bound=True,
+        is_human_room_bound=False,
+    )
+
+    ctx = MagicMock()
+    out = await handler(ctx=ctx, content="hello", mentions=["@bob"], chat_id="r1")
+
+    reset_spy.assert_called_once_with(ctx)
+    get_agent_tools_spy.assert_called_once_with(ctx, "r1")
+    # chat_id must NOT reach the AgentTools method call — AgentTools is
+    # constructor-scoped and its methods don't take chat_id.
+    fake_agent_tools.send_message.assert_awaited_once()
+    call_kwargs = fake_agent_tools.send_message.await_args.kwargs
+    assert "chat_id" not in call_kwargs
+    assert call_kwargs == {"content": "hello", "mentions": ["@bob"]}
+    assert "ok" in out
+
+
+async def test_unpinned_agent_handler_accepts_room_id_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_agent_tools = MagicMock()
+    fake_agent_tools.send_message = AsyncMock(return_value={"ok": True})
+    get_agent_tools_spy = MagicMock(return_value=fake_agent_tools)
+    monkeypatch.setattr(registrar, "get_agent_tools", get_agent_tools_spy)
+    monkeypatch.setattr(registrar, "reset_agent_tools_cache", MagicMock())
+    monkeypatch.setattr(registrar, "get_human_tools", MagicMock())
+
+    definition = TOOL_DEFINITIONS["thenvoi_send_message"]
+    extended = _extend_with_chat_id(definition.input_model, None)
+
+    # Exercise the dispatch path directly: validation via AliasChoices
+    # resolves ``room_id`` to ``chat_id`` inside the extended input model.
+    from thenvoi_mcp.tools.registrar import _invoke
+
+    out = await _invoke(
+        surface="agent",
+        tool_name=definition.name,
+        method_name=definition.method_name,
+        input_model=extended,
+        pinned_room_id=None,
+        is_agent_room_bound=True,
+        is_human_room_bound=False,
+        ctx=MagicMock(),
+        kwargs={"content": "hi", "mentions": ["@x"], "room_id": "r_alias"},
+    )
+    get_agent_tools_spy.assert_called_once()
+    assert get_agent_tools_spy.call_args.args[1] == "r_alias"
+    assert "ok" in out
+
+
+# ---------------------------------------------------------------------------
+# Pinned agent handler: schema + dispatch
+# ---------------------------------------------------------------------------
+
+
+async def test_pinned_agent_schema_hides_chat_id() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["agent"], tools=[], agent_key="k", room_id="r_pinned")
+    register_tools(mcp, cfg)
+
+    t = await _list_tool(mcp, "thenvoi_send_message")
+    assert t is not None
+    props = t.inputSchema.get("properties", {})
+    assert "chat_id" not in props
+    assert "room_id" not in props
+
+
+async def test_pinned_agent_handler_injects_room_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_agent_tools = MagicMock()
+    fake_agent_tools.send_message = AsyncMock(return_value={"ok": True})
+    get_agent_tools_spy = MagicMock(return_value=fake_agent_tools)
+    monkeypatch.setattr(registrar, "get_agent_tools", get_agent_tools_spy)
+    monkeypatch.setattr(registrar, "reset_agent_tools_cache", MagicMock())
+    monkeypatch.setattr(registrar, "get_human_tools", MagicMock())
+
+    definition = TOOL_DEFINITIONS["thenvoi_send_message"]
+    pinned = _extend_with_chat_id(definition.input_model, "r_pinned")
+    handler = make_handler(
+        tool_name=definition.name,
+        surface="agent",
+        method_name=definition.method_name,
+        input_model=pinned,
+        pinned_room_id="r_pinned",
+        is_agent_room_bound=True,
+        is_human_room_bound=False,
+    )
+
+    ctx = MagicMock()
+    await handler(ctx=ctx, content="hi", mentions=["@x"])
+
+    get_agent_tools_spy.assert_called_once_with(ctx, "r_pinned")
+
+
+# ---------------------------------------------------------------------------
+# Human room-bound handler
+# ---------------------------------------------------------------------------
+
+
+async def test_unpinned_human_room_bound_advertises_chat_id() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["human"], tools=[], user_key="k")
+    register_tools(mcp, cfg)
+
+    t = await _list_tool(mcp, "thenvoi_send_my_chat_message")
+    assert t is not None
+    props = t.inputSchema.get("properties", {})
+    required = t.inputSchema.get("required", [])
+    assert "chat_id" in props
+    assert "chat_id" in required
+
+
+async def test_unpinned_human_handler_passes_chat_id_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_human_tools = MagicMock()
+    fake_human_tools.send_my_chat_message = AsyncMock(return_value={"ok": True})
+
+    monkeypatch.setattr(
+        registrar, "get_human_tools", MagicMock(return_value=fake_human_tools)
+    )
+    monkeypatch.setattr(registrar, "reset_agent_tools_cache", MagicMock())
+    monkeypatch.setattr(registrar, "get_agent_tools", MagicMock())
+
+    definition = TOOL_DEFINITIONS["thenvoi_send_my_chat_message"]
+    handler = make_handler(
+        tool_name=definition.name,
+        surface="human",
+        method_name=definition.method_name,
+        input_model=definition.input_model,
+        pinned_room_id=None,
+        is_agent_room_bound=False,
+        is_human_room_bound=True,
+    )
+
+    ctx = MagicMock()
+    await handler(ctx=ctx, chat_id="r1", content="hi", recipients="@bob")
+
+    call_kwargs = fake_human_tools.send_my_chat_message.await_args.kwargs
+    assert call_kwargs["chat_id"] == "r1"
+    assert call_kwargs["content"] == "hi"
+
+
+async def test_pinned_human_handler_injects_chat_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_human_tools = MagicMock()
+    fake_human_tools.send_my_chat_message = AsyncMock(return_value={"ok": True})
+
+    monkeypatch.setattr(
+        registrar, "get_human_tools", MagicMock(return_value=fake_human_tools)
+    )
+    monkeypatch.setattr(registrar, "reset_agent_tools_cache", MagicMock())
+    monkeypatch.setattr(registrar, "get_agent_tools", MagicMock())
+
+    definition = TOOL_DEFINITIONS["thenvoi_send_my_chat_message"]
+    pinned = _pin_existing_chat_id(definition.input_model, "r_pin")
+    handler = make_handler(
+        tool_name=definition.name,
+        surface="human",
+        method_name=definition.method_name,
+        input_model=pinned,
+        pinned_room_id="r_pin",
+        is_agent_room_bound=False,
+        is_human_room_bound=True,
+    )
+
+    ctx = MagicMock()
+    await handler(ctx=ctx, content="hi", recipients="@x")
+
+    call_kwargs = fake_human_tools.send_my_chat_message.await_args.kwargs
+    assert call_kwargs["chat_id"] == "r_pin"
+
+
+async def test_pinned_human_room_bound_schema_hides_chat_id() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["human"], tools=[], user_key="k", room_id="r_pin")
+    register_tools(mcp, cfg)
+
+    t = await _list_tool(mcp, "thenvoi_send_my_chat_message")
+    assert t is not None
+    assert "chat_id" not in t.inputSchema.get("properties", {})
+
+
+# ---------------------------------------------------------------------------
+# Room-less tools stay unchanged regardless of pin state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("pin", [None, "r_pin"])
+@pytest.mark.parametrize(
+    "tool_name",
+    ["thenvoi_list_my_chats", "thenvoi_get_my_profile"],
+)
+async def test_room_less_human_tools_schema_unchanged_by_pin(
+    pin: str | None, tool_name: str
+) -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(scope=["human"], tools=[], user_key="k", room_id=pin)
+    register_tools(mcp, cfg)
+
+    t = await _list_tool(mcp, tool_name)
+    assert t is not None
+    props = t.inputSchema.get("properties", {})
+    # These tools have no chat_id in their underlying input model.
+    assert "chat_id" not in props
+
+
+async def test_room_less_list_my_contacts_unchanged_by_pin() -> None:
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["human"],
+        tools=["contacts"],
+        user_key="k",
+        room_id="r_pin",
+    )
+    register_tools(mcp, cfg)
+
+    t = await _list_tool(mcp, "thenvoi_list_my_contacts")
+    assert t is not None
+    assert "chat_id" not in t.inputSchema.get("properties", {})
+
+
+# ---------------------------------------------------------------------------
+# reset_agent_tools_cache is called at start of each invocation
+# ---------------------------------------------------------------------------
+
+
+async def test_reset_agent_tools_cache_called_on_every_invocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_agent_tools = MagicMock()
+    fake_agent_tools.send_message = AsyncMock(return_value={"ok": True})
+
+    reset_spy = MagicMock()
+    monkeypatch.setattr(registrar, "reset_agent_tools_cache", reset_spy)
+    monkeypatch.setattr(
+        registrar, "get_agent_tools", MagicMock(return_value=fake_agent_tools)
+    )
+    monkeypatch.setattr(registrar, "get_human_tools", MagicMock())
+
+    definition = TOOL_DEFINITIONS["thenvoi_send_message"]
+    extended = _extend_with_chat_id(definition.input_model, None)
+    handler = make_handler(
+        tool_name=definition.name,
+        surface="agent",
+        method_name=definition.method_name,
+        input_model=extended,
+        pinned_room_id=None,
+        is_agent_room_bound=True,
+        is_human_room_bound=False,
+    )
+
+    ctx = MagicMock()
+    await handler(ctx=ctx, content="a", mentions=["@x"], chat_id="r1")
+    await handler(ctx=ctx, content="b", mentions=["@x"], chat_id="r1")
+
+    assert reset_spy.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Old handler coexistence — legacy handwritten handler names do not collide
+# ---------------------------------------------------------------------------
+
+
+def test_new_tool_names_are_prefixed_no_collision_with_legacy() -> None:
+    # SDK names are all prefixed. Legacy handwritten handler names are not
+    # (e.g. ``list_my_contacts``, ``get_my_chat``). Any collision would have
+    # FastMCP warn & keep the first registration.
+    mcp = FastMCP(name="t")
+    cfg = Config(
+        scope=["agent", "human"],
+        tools=["contacts", "memory"],
+        agent_key="a",
+        user_key="u",
+    )
+    register_tools(mcp, cfg)
+
+    for name in _registered_names(mcp):
+        assert name.startswith("thenvoi_"), name

--- a/tests/unit/test_registrar.py
+++ b/tests/unit/test_registrar.py
@@ -315,6 +315,28 @@ async def test_unpinned_agent_handler_accepts_room_id_alias(
     assert "ok" in out
 
 
+async def test_validation_errors_report_fields() -> None:
+    definition = TOOL_DEFINITIONS["thenvoi_send_message"]
+    extended = _extend_with_chat_id(definition.input_model, None)
+
+    from thenvoi_mcp.tools.registrar import _invoke
+
+    with pytest.raises(ValueError, match="Invalid arguments") as exc_info:
+        await _invoke(
+            surface="agent",
+            tool_name=definition.name,
+            method_name=definition.method_name,
+            input_model=extended,
+            pinned_room_id=None,
+            is_agent_room_bound=True,
+            is_human_room_bound=False,
+            ctx=MagicMock(),
+            kwargs={"mentions": ["@x"], "room_id": "r_alias"},
+        )
+
+    assert "content" in str(exc_info.value)
+
+
 # ---------------------------------------------------------------------------
 # Pinned agent handler: schema + dispatch
 # ---------------------------------------------------------------------------
@@ -358,6 +380,37 @@ async def test_pinned_agent_handler_injects_room_id(
     await handler(ctx=ctx, content="hi", mentions=["@x"])
 
     get_agent_tools_spy.assert_called_once_with(ctx, "r_pinned")
+
+
+async def test_pinned_agent_handler_overrides_caller_chat_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_agent_tools = MagicMock()
+    fake_agent_tools.send_message = AsyncMock(return_value={"ok": True})
+    get_agent_tools_spy = MagicMock(return_value=fake_agent_tools)
+    monkeypatch.setattr(registrar, "get_agent_tools", get_agent_tools_spy)
+    monkeypatch.setattr(registrar, "reset_agent_tools_cache", MagicMock())
+    monkeypatch.setattr(registrar, "get_human_tools", MagicMock())
+
+    definition = TOOL_DEFINITIONS["thenvoi_send_message"]
+    pinned = _extend_with_chat_id(definition.input_model, "r_pinned")
+
+    from thenvoi_mcp.tools.registrar import _invoke
+
+    await _invoke(
+        surface="agent",
+        tool_name=definition.name,
+        method_name=definition.method_name,
+        input_model=pinned,
+        pinned_room_id="r_pinned",
+        is_agent_room_bound=True,
+        is_human_room_bound=False,
+        ctx=MagicMock(),
+        kwargs={"content": "hi", "mentions": ["@x"], "chat_id": "r_user"},
+    )
+
+    get_agent_tools_spy.assert_called_once()
+    assert get_agent_tools_spy.call_args.args[1] == "r_pinned"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_shared.py
+++ b/tests/unit/test_shared.py
@@ -67,10 +67,10 @@ def test_get_agent_tools_caches_per_room(monkeypatch):
     app_ctx = AppContext(client=fake_client, agent_rest=fake_agent_rest)
     ctx = _make_ctx(app_ctx)
 
-    constructed: list[str] = []
+    constructed: list[str | None] = []
 
     class FakeAgentTools:
-        def __init__(self, room_id: str, rest: object):
+        def __init__(self, room_id: str | None, rest: object):
             self.room_id = room_id
             self.rest = rest
             constructed.append(room_id)
@@ -90,7 +90,7 @@ def test_get_agent_tools_returns_distinct_instance_per_room(monkeypatch):
     ctx = _make_ctx(app_ctx)
 
     class FakeAgentTools:
-        def __init__(self, room_id: str, rest: object):
+        def __init__(self, room_id: str | None, rest: object):
             self.room_id = room_id
 
     monkeypatch.setattr(shared_mod, "_try_import_agent_tools", lambda: FakeAgentTools)
@@ -102,6 +102,24 @@ def test_get_agent_tools_returns_distinct_instance_per_room(monkeypatch):
     assert b.room_id == "room_B"
 
 
+def test_get_agent_tools_accepts_none_for_room_less_agent_tools(monkeypatch):
+    fake_client = MagicMock()
+    fake_agent_rest = MagicMock()
+    app_ctx = AppContext(client=fake_client, agent_rest=fake_agent_rest)
+    ctx = _make_ctx(app_ctx)
+
+    class FakeAgentTools:
+        def __init__(self, room_id: str | None, rest: object):
+            self.room_id = room_id
+
+    monkeypatch.setattr(shared_mod, "_try_import_agent_tools", lambda: FakeAgentTools)
+
+    result = get_agent_tools(ctx, None)
+
+    assert result.room_id is None
+    assert app_ctx._agent_tools_cache == {None: result}
+
+
 def test_reset_agent_tools_cache_clears_entries(monkeypatch):
     fake_client = MagicMock()
     fake_agent_rest = MagicMock()
@@ -109,7 +127,7 @@ def test_reset_agent_tools_cache_clears_entries(monkeypatch):
     ctx = _make_ctx(app_ctx)
 
     class FakeAgentTools:
-        def __init__(self, room_id: str, rest: object):
+        def __init__(self, room_id: str | None, rest: object):
             self.room_id = room_id
 
     monkeypatch.setattr(shared_mod, "_try_import_agent_tools", lambda: FakeAgentTools)


### PR DESCRIPTION
## Summary

Phase 3 of INT-338. Replaces handwritten per-tool `@mcp.tool()` registrations
with a scope-filtered loop over the SDK's `iter_tool_definitions(...)`. Each
`ToolDefinition` becomes a FastMCP tool whose handler dispatches to the Phase 1
`HumanTools` / `AgentTools` from `thenvoi-sdk-python`.

- New: `src/thenvoi_mcp/tools/registrar.py` — `register_tools(mcp, config)`.
- New: `tests/unit/test_registrar.py` — 28 tests.
- New: `tests/integration/test_forwarding.py` — 11 in-process MCP round-trip tests.
- Modified: `src/thenvoi_mcp/server.py` — calls `register_tools(mcp, config)` after the existing `load_tools()` invocation. Old handwritten handlers continue to register in parallel (SDK tool names are `thenvoi_`-prefixed and do not collide). Phase 4 (INT-352) deletes the handwritten handlers.

## Spec deviation (resolved with reviewer)

The Phase 3 spec text told the registrar to classify agent tools by looking
for a `room_id` field on `ToolDefinition.input_model.model_fields`. That
classifier does not work for agent tools: `AgentTools` is room-scoped via
its constructor, so the SDK input models only cover method arguments, not
the construction-time room id. Putting `room_id` on the input model would
create a mismatch between the input schema and the `AgentTools` method
signature.

**Resolution**: the registrar adds `chat_id` to the advertised schema of
every agent room-bound tool, with `AliasChoices(\"chat_id\", \"room_id\")` so
both names work at the wire. This keeps the SDK clean (pure tool logic),
matches today's MCP wire format exactly (zero breaking change for existing
MCP consumers), and still satisfies the spec's intent (scope-filtered
registry + pinned-room field stripping).

The set of agent room-bound tools is enumerated in
`AGENT_ROOM_BOUND_TOOL_NAMES`, derived from today's agent handlers that
currently take `chat_id` in `src/thenvoi_mcp/tools/agent/*.py`. Rationale
is documented in the module docstring.

The human-side classifier is unchanged: human input models already carry a
`chat_id` field where applicable (Phase 1 derived them from `HumanTools`
method signatures), so `model_fields`-based detection works on that surface.

## Old handler coexistence

Chose option (a): keep the old handwritten handler imports and add the
new registrar after them. FastMCP logs a warning and keeps the
first-registered tool on duplicate names; since SDK tool names are
`thenvoi_`-prefixed (e.g. `thenvoi_list_my_contacts`) and today's
handwritten handler names are unprefixed (e.g. `list_my_contacts`), there
is no collision. Both surfaces coexist during the transition. Phase 4
(INT-352) deletes the handwritten handlers wholesale.

## Dependency

Depends on thenvoi/thenvoi-sdk-python#264 (Phase 1, INT-349). Local
development pin is in the PR checkout notes; the committed
`pyproject.toml` / `uv.lock` are unchanged from Phase 2.

## Test plan

- [x] `uv run pytest tests/unit/test_registrar.py --no-cov -v` — 28 passed
- [x] `uv run pytest tests/integration/test_forwarding.py --no-cov -v` — 11 passed
- [x] `uv run pytest tests/unit/ tests/integration/test_forwarding.py --no-cov` — 86 passed
- [x] `uv run pre-commit run --all-files` — ruff, ruff-format, pyrefly all green
- [ ] Smoke-test against live API after Phase 1 (INT-349) merges

## Linked

- Parent: INT-338
- Phase 1 (SDK): thenvoi/thenvoi-sdk-python#264 (INT-349)
- Phase 2 (this repo): #99 (INT-350, stacked base)
- Blocks: INT-352 (Phase 4, handwritten handler deletion)