### PR TITLE
fix(ci): retarget PR triggers from develop to dev/main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [develop]
+    branches: [dev, main]
 
 jobs:
 

--- a/claude.md
+++ b/claude.md
@@ -82,4 +82,4 @@ Wildcard port matching is supported: `"localhost:*"` matches `localhost:8000`, `
 
 ## Git Workflow
 
-- Default branch: `develop` (PRs target here)
+- Default branch: `dev` (PRs target here)


### PR DESCRIPTION
## Summary

The default branch was renamed from `develop` to `dev` in #98 (INT-347), but `.github/workflows/ci.yml` still had `pull_request.branches: [develop]`. Consequence: no PR against `dev` has had CI run since the rename — only the PR Title check fires. You can see the pattern on #99, #100, #101, and earlier (#64, #97, #98).

Fix is one line — align the filter with the SDK repo's convention (`[dev, main]`). Also updates `CLAUDE.md`'s Git Workflow note, which still said `develop`.

## Test plan

- [ ] Confirm CI runs on this PR (which targets `dev`)
- [ ] Spot-check that lint + test jobs actually execute and pass