### PR TITLE
chore(ci): add test and packaging jobs (INT-443)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,84 @@ jobs:
 
     - name: Run pre-commit hooks
       run: uv run pre-commit run --all-files
+
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12']
+      fail-fast: false
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Configure git to use HTTPS for GitHub
+      run: git config --global url."https://github.com/".insteadOf "git@github.com:"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        cache-dependency-glob: "**/pyproject.toml"
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: uv sync --extra dev
+
+    - name: Run unit tests
+      run: uv run pytest --ignore=tests/integration/
+
+
+  packaging:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Configure git to use HTTPS for GitHub
+      run: git config --global url."https://github.com/".insteadOf "git@github.com:"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    - name: Build wheel
+      run: uv build --wheel
+
+    - name: Install from wheel (isolated, no extras)
+      run: |
+        uv venv /tmp/test-install
+        uv pip install dist/*.whl --python /tmp/test-install/bin/python
+
+    - name: Verify core imports (no extras)
+      run: |
+        /tmp/test-install/bin/python -c "
+        from thenvoi_mcp import __version__, settings
+        from thenvoi_mcp.server import run
+        from thenvoi_mcp.shared import mcp, get_app_context, AppContextType
+        print('Core imports successful')
+        "
+
+    - name: Install with dev extras
+      run: |
+        WHEEL=$(ls dist/*.whl)
+        uv pip install "${WHEEL}[dev]" --python /tmp/test-install/bin/python
+
+    - name: Verify imports with dev extras
+      run: |
+        /tmp/test-install/bin/python -c "
+        from thenvoi_mcp import __version__, settings
+        from thenvoi_mcp.server import run
+        from thenvoi_mcp.shared import mcp, get_app_context, AppContextType
+        print('Dev-extra imports successful')
+        "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
+    - name: Configure git to use HTTPS for GitHub
+      run: git config --global url."https://github.com/".insteadOf "git@github.com:"
+
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
+        cache-dependency-glob: "**/uv.lock"
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -50,7 +51,7 @@ jobs:
       uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
-        cache-dependency-glob: "**/pyproject.toml"
+        cache-dependency-glob: "**/uv.lock"
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
@@ -58,7 +59,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: uv sync --extra dev
+      run: uv sync --frozen --extra dev
 
     - name: Run unit tests
       run: uv run pytest --ignore=tests/integration/
@@ -70,11 +71,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
-    - name: Configure git to use HTTPS for GitHub
-      run: git config --global url."https://github.com/".insteadOf "git@github.com:"
-
     - name: Install uv
       uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        cache-dependency-glob: "**/uv.lock"
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -95,7 +96,6 @@ jobs:
         from thenvoi_mcp import __version__, settings
         from thenvoi_mcp.server import run
         from thenvoi_mcp.shared import mcp, get_app_context, AppContextType
-        print('Core imports successful')
         "
 
     - name: Install with dev extras
@@ -109,5 +109,4 @@ jobs:
         from thenvoi_mcp import __version__, settings
         from thenvoi_mcp.server import run
         from thenvoi_mcp.shared import mcp, get_app_context, AppContextType
-        print('Dev-extra imports successful')
         "


### PR DESCRIPTION
## Summary

Closes [INT-443](https://linear.app/thenvoi/issue/INT-443/chore-add-proper-ci-checks-to-thenvoi-mcp-repo). Extends `.github/workflows/ci.yml` beyond the existing pre-commit `lint` job by porting two jobs from `thenvoi-sdk-python/.github/workflows/ci.yml`:

- **`test`** — matrix on Python `3.11` and `3.12`, `fail-fast: false`, runs `uv run pytest --ignore=tests/integration/`. Matches `requires-python = ">=3.11"` in `pyproject.toml`. Integration tests stay out of PR CI since they need real API credentials (`.env.test`); auto-skip behavior on missing creds is preserved for anyone who wants to opt in later.
- **`packaging`** — `uv build --wheel`, install into an isolated venv with no extras, smoke-import the public surface (`__version__`, `settings`, `server.run`, `shared.{mcp, get_app_context, AppContextType}`), then reinstall with `[dev]` and re-verify.

Triggers remain `pull_request: branches: [dev, main]` (already correct after #102).

## Test plan

- [x] `uv sync --extra dev` succeeds locally
- [x] `uv run pytest --ignore=tests/integration/` → **151 passed**, 87.86% coverage (above the 20% floor)
- [x] `uv build --wheel` succeeds; wheel installs into an isolated 3.12 venv with no extras
- [x] Smoke imports succeed after the no-extras install
- [x] Smoke imports succeed again after `pip install "*.whl[dev]"`
- [ ] Confirm in GitHub Actions that `lint`, `test (3.11)`, `test (3.12)`, and `packaging` all run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)