### PR TITLE
chore: rename "external agent" to "remote agent" (INT-458)

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ For users authenticated with user API keys.
 #### Agent Management
 
 - `list_my_agents` - List agents owned by the user
-- `register_my_agent` - Register a new external agent (returns API key)
+- `register_my_agent` - Register a new remote agent (returns API key)
 
 #### Chat Management
 

--- a/src/thenvoi_mcp/tools/agent/agent_messages.py
+++ b/src/thenvoi_mcp/tools/agent/agent_messages.py
@@ -127,7 +127,7 @@ def get_agent_chat_context(
     - All messages the agent sent (any type: text, tool_call, tool_result, thought, etc.)
     - All text messages that @mention the agent
 
-    Use this to load the complete context an external agent needs to resume execution.
+    Use this to load the complete context a remote agent needs to resume execution.
     Messages are returned in chronological order (oldest first).
 
     Args:

--- a/src/thenvoi_mcp/tools/human/human_agents.py
+++ b/src/thenvoi_mcp/tools/human/human_agents.py
@@ -28,7 +28,7 @@ def register_my_agent(
     name: str,
     description: str,
 ) -> str:
-    """Register a new external agent.
+    """Register a new remote agent.
 
     Returns the agent details including API key. Save the API key - it's only shown once!
 

--- a/uv.lock
+++ b/uv.lock
@@ -1830,7 +1830,7 @@ wheels = [
 
 [[package]]
 name = "thenvoi-mcp"
-version = "1.2.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },

--- a/uv.lock
+++ b/uv.lock
@@ -1830,7 +1830,7 @@ wheels = [
 
 [[package]]
 name = "thenvoi-mcp"
-version = "1.1.1"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary

- Renames user-facing "external agent" wording to "remote agent" in tool docstrings (`register_my_agent`, `get_agent_chat_context`) and the README tool list.
- Part of [INT-291](https://linear.app/thenvoi/issue/INT-291) — unified "remote agent" terminology across integration repos. Linear: [INT-458](https://linear.app/thenvoi/issue/INT-458).
- Includes a `uv.lock` sync (editable `thenvoi-mcp` entry 1.1.1 → 1.2.0) that the pre-commit hook required; matches the already-released `pyproject.toml` version.

No code symbols, public APIs, env vars, CLI flags, config keys, or tool names changed — only descriptive text.

## Test plan

- [x] `grep -rIi external` across the repo returns zero matches
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format . --check` clean
- [x] `uv run pytest tests/ --ignore=tests/integration/` — 151 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)