### PR TITLE
fix(ci): use band-testing-python from PyPI instead of git URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
-    - name: Configure git to use HTTPS for GitHub
-      run: git config --global url."https://github.com/".insteadOf "git@github.com:"
-
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -44,9 +41,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
-    - name: Configure git to use HTTPS for GitHub
-      run: git config --global url."https://github.com/".insteadOf "git@github.com:"
-
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -70,9 +64,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
-
-    - name: Configure git to use HTTPS for GitHub
-      run: git config --global url."https://github.com/".insteadOf "git@github.com:"
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dev = [
     "pytest-mock>=3.12.0",
     "python-dotenv>=1.0.0",
     "respx>=0.20.0",
-    "thenvoi-testing-python @ git+https://github.com/thenvoi/thenvoi-testing-python.git@thenvoi-testing-python-v0.1.1",
+    "band-testing-python>=0.1.4",
 ]
 # LangGraph agent example dependencies
 langgraph = [

--- a/uv.lock
+++ b/uv.lock
@@ -44,6 +44,21 @@ wheels = [
 ]
 
 [[package]]
+name = "band-testing-python"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/2b/47b6a5afca2f6c41f5c75557164654512af96b2a06f09fe50fac35e86d1d/band_testing_python-0.1.4.tar.gz", hash = "sha256:3a4e3bd3b8a37bda5d587a6290cc7d1a8c4b4ecbe7bb348716d632de314d87f7", size = 61988, upload-time = "2026-04-28T13:24:46.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/63/f53ebd26ac8ce6e4ee9e523e962955adb4dc003f4d2f70b582bd85863c79/band_testing_python-0.1.4-py3-none-any.whl", hash = "sha256:b5b45d56646fcb3fb1c7b3ca0925dc7354b93beaab11eddeb85a7b7550b0376c", size = 25696, upload-time = "2026-04-28T13:24:44.441Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.11.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1101,7 +1116,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "4.5.0"
+version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
@@ -1110,9 +1125,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/9b/6a4ffb4ed980519da959e1cf3122fc6cb41211daa58dbae1c73c0e519a37/pre_commit-4.5.0.tar.gz", hash = "sha256:dc5a065e932b19fc1d4c653c6939068fe54325af8e741e74e88db4d28a4dd66b", size = 198428, upload-time = "2025-11-22T21:02:42.304Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/c4/b2d28e9d2edf4f1713eb3c29307f1a63f3d67cf09bdda29715a36a68921a/pre_commit-4.5.0-py2.py3-none-any.whl", hash = "sha256:25e2ce09595174d9c97860a95609f9f852c0614ba602de3561e267547f2335e1", size = 226429, upload-time = "2025-11-22T21:02:40.836Z" },
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -1841,13 +1856,13 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "band-testing-python" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "python-dotenv" },
     { name = "respx" },
-    { name = "thenvoi-testing-python" },
 ]
 examples = [
     { name = "langchain" },
@@ -1883,6 +1898,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "band-testing-python", marker = "extra == 'dev'", specifier = ">=0.1.4" },
     { name = "langchain", marker = "extra == 'examples'", specifier = ">=0.3.0" },
     { name = "langchain", marker = "extra == 'langchain'", specifier = ">=0.3.0" },
     { name = "langchain-core", marker = "extra == 'examples'", specifier = ">=1.2.5" },
@@ -1899,7 +1915,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.23.0" },
     { name = "pydantic-settings", specifier = ">=2.1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.12.0" },
     { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.0.0" },
@@ -1908,7 +1924,6 @@ requires-dist = [
     { name = "python-dotenv", marker = "extra == 'langgraph'", specifier = ">=1.0.0" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.20.0" },
     { name = "thenvoi-client-rest", specifier = ">=0.0.4" },
-    { name = "thenvoi-testing-python", marker = "extra == 'dev'", git = "https://github.com/thenvoi/thenvoi-testing-python.git?rev=thenvoi-testing-python-v0.1.1" },
     { name = "uvicorn", specifier = ">=0.30.0" },
 ]
 provides-extras = ["dev", "langgraph", "langchain", "examples"]
@@ -1916,21 +1931,10 @@ provides-extras = ["dev", "langgraph", "langchain", "examples"]
 [package.metadata.requires-dev]
 dev = [
     { name = "commitizen", specifier = ">=3.13.0" },
-    { name = "pre-commit", specifier = ">=4.4.0" },
+    { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pydantic-settings", specifier = ">=2.1.0" },
     { name = "pyrefly", specifier = ">=0.2.0" },
     { name = "ruff", specifier = ">=0.8.0" },
-]
-
-[[package]]
-name = "thenvoi-testing-python"
-version = "0.1.1"
-source = { git = "https://github.com/thenvoi/thenvoi-testing-python.git?rev=thenvoi-testing-python-v0.1.1#916551e1c2b4c791366bccb64e67c41849365f00" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace `thenvoi-testing-python @ git+https://github.com/thenvoi/thenvoi-testing-python.git@…` with the PyPI-published `band-testing-python>=0.1.4` in the `dev` extra. The PyPI package still ships the `thenvoi_testing` module, so no test imports change.
- Refresh `uv.lock` to point at the registry source.
- Drop the three now-unused `git config --global url."https://github.com/".insteadOf "git@github.com:"` steps from `.github/workflows/ci.yml` — they only existed to support the git URL dep.

## Why

The 1.3.0 release run [26146125849](https://github.com/thenvoi/thenvoi-mcp/actions/runs/26146125849/job/76902026408) failed at `Publish band-mcp to PyPI` with:

> 400 Can't have direct dependency: thenvoi-testing-python @ git+https://github.com/thenvoi/thenvoi-testing-python.git@thenvoi-testing-python-v0.1.1 ; extra == "dev"

PyPI does not accept distributions whose metadata contains PEP 440 direct URL references, even on optional extras.

## Test plan

- [x] `uv sync --extra dev` resolves cleanly with the new dep
- [x] `uv run pytest tests/ --ignore=tests/integration/` — 265 passed
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [ ] Confirm next release run uploads to PyPI successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)