### PR TITLE
feat: rebrand MCP package to Band

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
-# Thenvoi MCP Server Configuration
+# Band MCP Server Configuration
 # Copy this file to .env and fill in your values
 
-# Required: Thenvoi API key from https://app.thenvoi.com/settings/api-keys
-THENVOI_API_KEY=your_api_key_here
+# Required: Band API key from https://app.band.ai/settings/api-keys
+BAND_API_KEY=your_api_key_here
 
-# Required: Thenvoi API base URL
-THENVOI_BASE_URL=https://app.thenvoi.com
+# Required: Band API base URL
+BAND_BASE_URL=https://app.band.ai
 
 # Optional: OpenAI API key for running example agents (examples/*.py)
 OPENAI_API_KEY=your_api_key_here

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,10 +70,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-groups
 
-      - name: Build as band-mcp
-        run: |
-          sed -i 's/^name = "thenvoi-mcp"/name = "band-mcp"/' pyproject.toml
-          uv build
+      - name: Build band-mcp
+        run: uv build
 
       - name: Publish band-mcp to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Thenvoi MCP
+# Contributing to Band MCP
 
-Thank you for your interest in contributing to Thenvoi MCP! This document provides guidelines and instructions for contributing.
+Thank you for your interest in contributing to Band MCP! This document provides guidelines and instructions for contributing.
 
 ## Development Setup
 
@@ -14,12 +14,12 @@ Thank you for your interest in contributing to Thenvoi MCP! This document provid
 1. Fork the repository
 2. Clone your fork:
    ```bash
-   git clone https://github.com/YOUR_USERNAME/thenvoi-mcp.git
-   cd thenvoi-mcp
+   git clone https://github.com/YOUR_USERNAME/band-mcp.git
+   cd band-mcp
    ```
 3. Add upstream remote:
    ```bash
-   git remote add upstream https://github.com/thenvoi/thenvoi-mcp.git
+   git remote add upstream https://github.com/thenvoi/band-mcp.git
    ```
 4. Install dependencies:
    ```bash
@@ -53,7 +53,7 @@ Thank you for your interest in contributing to Thenvoi MCP! This document provid
    # Unit tests
    uv run pytest tests/ --ignore=tests/integration/ -v
 
-   # Integration tests (requires THENVOI_API_KEY)
+   # Integration tests (requires BAND_API_KEY)
    uv run pytest tests/integration/ -v -s --no-cov
    ```
 
@@ -194,7 +194,7 @@ def test_my_tool(mock_ctx, mock_agent_api):
 
 **Integration Tests:**
 - Place in `tests/integration/`
-- Require `THENVOI_API_KEY` environment variable (set in `.env.test`)
+- Require `BAND_API_KEY` environment variable (set in `.env.test`)
 - Use `@requires_api` decorator to skip if API key is not set
 
 ## Pull Request Guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ uv run pytest tests/integration/ -v -s --no-cov
 
 ### Writing Tests
 
-This project uses the shared `thenvoi-testing-python` package for test fixtures and utilities.
+This project uses the shared `band-testing-python` package for test fixtures and utilities.
 
 **Unit Tests:**
 - Place in `tests/`

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Thenvoi
+Copyright (c) 2025 band.ai
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -438,8 +438,8 @@ WARN  unknown --scope value 'huamn' — did you mean 'human'? ignoring.
 | `BAND_MCP_SCOPE` / `THENVOI_MCP_SCOPE`         | Comma-separated scope list (default: `agent`)     |
 | `BAND_MCP_TOOLS` / `THENVOI_MCP_TOOLS`         | Opt-in tool groups: `contacts`, `memory`          |
 | `BAND_MCP_ROOM_ID` / `THENVOI_MCP_ROOM_ID`     | Pinned room id (optional)                         |
-| `BAND_API_KEY`                              | Legacy single-key path — **still supported**      |
-| `BAND_BASE_URL`                             | API base URL (default: `https://app.band.ai`) |
+| `BAND_API_KEY` / `THENVOI_API_KEY`          | Legacy single-key path — **still supported**      |
+| `BAND_BASE_URL` / `THENVOI_BASE_URL`        | API base URL (default: `https://app.band.ai`)     |
 | `TRANSPORT`                                    | `stdio` (default) or `sse`                        |
 | `HOST` / `PORT`                                | SSE bind host/port                                |
 
@@ -449,6 +449,10 @@ Legacy `.env` setups keep working unchanged:
 # Legacy, still supported
 BAND_API_KEY=your-api-key-here
 BAND_BASE_URL=https://app.band.ai
+
+# Older Thenvoi names also remain supported
+THENVOI_API_KEY=your-api-key-here
+THENVOI_BASE_URL=https://app.thenvoi.com
 ```
 
 When both a scope-specific key (`BAND_USER_KEY` / `BAND_AGENT_KEY`) and
@@ -479,7 +483,7 @@ BAND_LOG_LEVEL=debug band-mcp
 - Regenerate API key at [app.band.ai/settings/api-keys](https://app.band.ai/settings/api-keys)
 - Test API directly:
   ```bash
-  curl -H "Authorization: Bearer $BAND_API_KEY" \
+  curl -H "X-API-Key: $BAND_API_KEY" \
     https://app.band.ai/api/v1/health
   ```
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Thenvoi MCP Server
+# Band MCP Server
 
 ![Python Version](https://img.shields.io/badge/python-3.11%2B-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![MCP Protocol](https://img.shields.io/badge/MCP-1.0-purple)
 
-A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that provides seamless integration with the Thenvoi AI platform. Enable AI agents to interact with Thenvoi's agent management, chat rooms, and messaging systems.
+A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that provides seamless integration with the Band AI platform. Enable AI agents to interact with Band's agent management, chat rooms, and messaging systems.
 
 ## ✨ Features
 
@@ -22,7 +22,7 @@ A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that pr
 ### Prerequisites
 
 - Python 3.11 or higher
-- Thenvoi API key from [app.thenvoi.com/settings/api-keys](https://app.thenvoi.com/settings/api-keys)
+- Band API key from [app.band.ai/settings/api-keys](https://app.band.ai/settings/api-keys)
 
 ### Install from PyPI
 
@@ -32,11 +32,11 @@ pip install band-mcp
 uv tool install band-mcp
 ```
 
-This installs the `thenvoi-mcp` CLI on your PATH. No repo clone, no `uv` directory flags, no absolute paths required.
+This installs the `band-mcp` CLI on your PATH. No repo clone, no `uv` directory flags, no absolute paths required.
 
 > **Getting Your API Key**
 >
-> 1. Log in to [Thenvoi](https://app.thenvoi.com)
+> 1. Log in to [Band](https://app.band.ai)
 > 2. Navigate to **Settings → API Keys**
 > 3. Click **Create New API Key**
 > 4. Copy the key immediately (won't be shown again)
@@ -47,13 +47,13 @@ The STDIO transport is perfect for local development and IDE integration. The se
 
 ### IDE Integration
 
-Configure your AI assistant to use the Thenvoi MCP Server with the following JSON structure:
+Configure your AI assistant to use the Band MCP Server with the following JSON structure:
 
 ```json
 {
   "mcpServers": {
-    "thenvoi": {
-      "command": "thenvoi-mcp",
+    "band": {
+      "command": "band-mcp",
       "args": [
         "--scope",
         "agent",
@@ -61,18 +61,18 @@ Configure your AI assistant to use the Thenvoi MCP Server with the following JSO
         "contacts"
       ],
       "env": {
-        "THENVOI_AGENT_KEY": "thnv_a_your_agent_key",
-        "THENVOI_USER_KEY": "thnv_u_your_user_key",
-        "THENVOI_BASE_URL": "https://app.thenvoi.com"
+        "BAND_AGENT_KEY": "thnv_a_your_agent_key",
+        "BAND_USER_KEY": "thnv_u_your_user_key",
+        "BAND_BASE_URL": "https://app.band.ai"
       }
     }
   }
 }
 ```
 
-> **Note:** This assumes `band-mcp` is installed via `pip` or `uv tool install` so the `thenvoi-mcp` command is on your PATH. If you prefer to run from a local checkout, see the [Development setup](#-development) section.
+> **Note:** This assumes `band-mcp` is installed via `pip` or `uv tool install` so the `band-mcp` command is on your PATH. If you prefer to run from a local checkout, see the [Development setup](#-development) section.
 
-> **Legacy single-key setups (`THENVOI_API_KEY`) still work** — see the Configuration section below for details and the breaking-change note about `--tools contacts`.
+> **Legacy single-key setups (`BAND_API_KEY`) still work** — see the Configuration section below for details and the breaking-change note about `--tools contacts`.
 
 <details>
 <summary><strong>Cursor Setup</strong></summary>
@@ -86,7 +86,7 @@ Configure your AI assistant to use the Thenvoi MCP Server with the following JSO
 5. Update the path and API credentials
 6. Save and restart Cursor
 
-The Thenvoi tools will appear automatically in the chat interface.
+The Band tools will appear automatically in the chat interface.
 
 </details>
 
@@ -104,7 +104,7 @@ The Thenvoi tools will appear automatically in the chat interface.
 5. Save the file
 6. Restart Claude Desktop
 
-The Thenvoi tools will appear in the tools panel.
+The Band tools will appear in the tools panel.
 
 </details>
 
@@ -122,11 +122,11 @@ The Thenvoi tools will appear in the tools panel.
 ```json
 {
   "claude.mcpServers": {
-    "thenvoi": {
-      "command": "thenvoi-mcp",
+    "band": {
+      "command": "band-mcp",
       "env": {
-        "THENVOI_API_KEY": "your_api_key_here",
-        "THENVOI_BASE_URL": "https://app.thenvoi.com"
+        "BAND_API_KEY": "your_api_key_here",
+        "BAND_BASE_URL": "https://app.band.ai"
       }
     }
   }
@@ -140,7 +140,7 @@ The Thenvoi tools will appear in the tools panel.
    - **Mac:** `Cmd+Shift+P` → "Reload Window"
    - **Windows:** `Ctrl+Shift+P` → "Reload Window"
 
-The Thenvoi tools will be available in Claude Code.
+The Band tools will be available in Claude Code.
 
 </details>
 
@@ -150,18 +150,18 @@ For testing or standalone usage without an IDE:
 
 ```bash
 # After installing band-mcp from PyPI
-THENVOI_API_KEY=your-key thenvoi-mcp
+BAND_API_KEY=your-key band-mcp
 
 # Or, from a local checkout
-uv run thenvoi-mcp
+uv run band-mcp
 ```
 
 **Expected output:**
 
 ```
-2025-11-19 17:09:51,621 - thenvoi-mcp - INFO - Starting thenvoi-mcp-server v1.0.0
-2025-11-19 17:09:51,621 - thenvoi-mcp - INFO - Base URL: https://app.thenvoi.com
-2025-11-19 17:09:51,621 - thenvoi-mcp - INFO - Server ready - listening for MCP protocol messages on STDIO
+2025-11-19 17:09:51,621 - band-mcp - INFO - Starting band-mcp-server v1.0.0
+2025-11-19 17:09:51,621 - band-mcp - INFO - Base URL: https://app.band.ai
+2025-11-19 17:09:51,621 - band-mcp - INFO - Server ready - listening for MCP protocol messages on STDIO
 ```
 
 > **✨ Note:** When configured in your AI assistant (Cursor/Claude Desktop/Claude Code), **the server starts automatically**. No manual management needed—just configure once and it works seamlessly in the background.
@@ -172,20 +172,20 @@ For cloud deployments, Docker containers, or shared team environments, use the S
 
 ```bash
 # Start SSE server on default port 8000
-thenvoi-mcp --transport sse
+band-mcp --transport sse
 
 # Custom host and port
-thenvoi-mcp --transport sse --host 0.0.0.0 --port 3000
+band-mcp --transport sse --host 0.0.0.0 --port 3000
 ```
 
 **Expected output:**
 
 ```
-2025-12-18 17:15:55 - thenvoi-mcp - INFO - Starting thenvoi-mcp-server v1.0.0
-2025-12-18 17:15:55 - thenvoi-mcp - INFO - Base URL: https://app.thenvoi.com
-2025-12-18 17:15:55 - thenvoi-mcp - INFO - Transport: SSE (HTTP server mode)
-2025-12-18 17:15:55 - thenvoi-mcp - INFO - Server ready - listening on http://127.0.0.1:3000
-2025-12-18 17:15:55 - thenvoi-mcp - INFO - SSE endpoint: /sse | Messages endpoint: /messages/
+2025-12-18 17:15:55 - band-mcp - INFO - Starting band-mcp-server v1.0.0
+2025-12-18 17:15:55 - band-mcp - INFO - Base URL: https://app.band.ai
+2025-12-18 17:15:55 - band-mcp - INFO - Transport: SSE (HTTP server mode)
+2025-12-18 17:15:55 - band-mcp - INFO - Server ready - listening on http://127.0.0.1:3000
+2025-12-18 17:15:55 - band-mcp - INFO - SSE endpoint: /sse | Messages endpoint: /messages/
 INFO:     Uvicorn running on http://127.0.0.1:3000 (Press CTRL+C to quit)
 ```
 
@@ -196,7 +196,7 @@ SSE requires maintaining a persistent connection. Use three terminals:
 **Terminal 1 - Start the server:**
 
 ```bash
-thenvoi-mcp --transport sse --port 3000
+band-mcp --transport sse --port 3000
 ```
 
 **Terminal 2 - Connect to SSE stream (keep running):**
@@ -241,13 +241,13 @@ You can also configure via environment variables:
 export TRANSPORT=sse
 export HOST=0.0.0.0
 export PORT=3000
-thenvoi-mcp
+band-mcp
 ```
 
 ### Testing with MCP Inspector
 
 ```bash
-npx @modelcontextprotocol/inspector thenvoi-mcp
+npx @modelcontextprotocol/inspector band-mcp
 ```
 
 ## 🔨 Available Tools
@@ -325,12 +325,12 @@ For users authenticated with user API keys.
 
 ### Agent Framework Examples
 
-We provide complete examples showing how to integrate Thenvoi MCP tools with popular agent frameworks. All examples use `langchain-mcp-adapters` to load the MCP tools.
+We provide complete examples showing how to integrate Band MCP tools with popular agent frameworks. All examples use `langchain-mcp-adapters` to load the MCP tools.
 
 **Prerequisites for all examples:**
 
 - OpenAI API key (for the LLM)
-- Thenvoi API key
+- Band API key
 
 **Installation Options:**
 
@@ -354,7 +354,7 @@ Uses LangGraph's StateGraph for building agents with MCP tools.
 ```bash
 # Set your API keys
 export OPENAI_API_KEY="sk-..."
-export THENVOI_API_KEY="thnv_..."
+export BAND_API_KEY="thnv_..."
 
 # Run the interactive agent
 uv run examples/langgraph_agent.py
@@ -362,7 +362,7 @@ uv run examples/langgraph_agent.py
 
 **What it does:**
 
-- Loads all Thenvoi MCP tools (14 agent + 11 human = 25 total)
+- Loads all Band MCP tools (14 agent + 11 human = 25 total)
 - Creates an interactive chat loop with a GPT-4o powered agent
 - The agent can manage chats, send messages, manage participants, and more
 - Type `exit`, `quit`, or `q` to exit
@@ -376,7 +376,7 @@ Uses LangChain's classic AgentExecutor pattern with OpenAI functions.
 ```bash
 # Set your API keys
 export OPENAI_API_KEY="sk-..."
-export THENVOI_API_KEY="thnv_..."
+export BAND_API_KEY="thnv_..."
 
 # Run the interactive agent
 uv run examples/langchain_agent.py
@@ -394,31 +394,31 @@ See `examples/langchain_agent.py` for the complete implementation.
 
 ### Credentials and scope (new in v1.2.0)
 
-`thenvoi-mcp` now takes explicit dual credentials and lets operators pick which
+`band-mcp` now takes explicit dual credentials and lets operators pick which
 scopes and tool groups to serve:
 
 ```bash
 # One credential per scope
-export THENVOI_USER_KEY=thnv_u_your_user_key      # or BAND_USER_KEY
-export THENVOI_AGENT_KEY=thnv_a_your_agent_key    # or BAND_AGENT_KEY
+export BAND_USER_KEY=thnv_u_your_user_key      # or THENVOI_USER_KEY
+export BAND_AGENT_KEY=thnv_a_your_agent_key    # or THENVOI_AGENT_KEY
 
 # Serve both scopes in one process (default: agent only)
-uv run thenvoi-mcp --scope agent,human
+uv run band-mcp --scope agent,human
 
 # Opt into contact-directory / memory tools
-uv run thenvoi-mcp --scope agent --tools contacts,memory
+uv run band-mcp --scope agent --tools contacts,memory
 
 # Pin the whole server to a single chat/room
-uv run thenvoi-mcp --scope agent --room-id r_123
+uv run band-mcp --scope agent --room-id r_123
 ```
 
-Resolution precedence per field: `CLI flag > THENVOI_* env > BAND_* env`. The
-legacy `THENVOI_API_KEY` env is still honored as a fallback — see below.
+Resolution precedence per field: `CLI flag > BAND_* env > THENVOI_* env`. The
+legacy `BAND_API_KEY` env is still honored as a fallback — see below.
 
 **Breaking change note for `--tools`.** Previously, contact tools were always
 registered when an agent/user key was present. The new default is `--tools []`
 (no optional groups). Operators who relied on contact tools being on must now
-pass `--tools contacts` (or set `THENVOI_MCP_TOOLS=contacts`). Memory tools
+pass `--tools contacts` (or set `BAND_MCP_TOOLS=contacts`). Memory tools
 remain opt-in via `--tools memory`.
 
 Unknown `--scope` / `--tools` values do not fail startup; they're logged at
@@ -433,13 +433,13 @@ WARN  unknown --scope value 'huamn' — did you mean 'human'? ignoring.
 
 | Variable                                       | Purpose                                           |
 | ---------------------------------------------- | ------------------------------------------------- |
-| `THENVOI_USER_KEY` / `BAND_USER_KEY`           | User (human-scope) API key (`thnv_u_...`)         |
-| `THENVOI_AGENT_KEY` / `BAND_AGENT_KEY`         | Agent-scope API key (`thnv_a_...`)                |
-| `THENVOI_MCP_SCOPE` / `BAND_MCP_SCOPE`         | Comma-separated scope list (default: `agent`)     |
-| `THENVOI_MCP_TOOLS` / `BAND_MCP_TOOLS`         | Opt-in tool groups: `contacts`, `memory`          |
-| `THENVOI_MCP_ROOM_ID` / `BAND_MCP_ROOM_ID`     | Pinned room id (optional)                         |
-| `THENVOI_API_KEY`                              | Legacy single-key path — **still supported**      |
-| `THENVOI_BASE_URL`                             | API base URL (default: `https://app.thenvoi.com`) |
+| `BAND_USER_KEY` / `THENVOI_USER_KEY`           | User (human-scope) API key (`thnv_u_...`)         |
+| `BAND_AGENT_KEY` / `THENVOI_AGENT_KEY`         | Agent-scope API key (`thnv_a_...`)                |
+| `BAND_MCP_SCOPE` / `THENVOI_MCP_SCOPE`         | Comma-separated scope list (default: `agent`)     |
+| `BAND_MCP_TOOLS` / `THENVOI_MCP_TOOLS`         | Opt-in tool groups: `contacts`, `memory`          |
+| `BAND_MCP_ROOM_ID` / `THENVOI_MCP_ROOM_ID`     | Pinned room id (optional)                         |
+| `BAND_API_KEY`                              | Legacy single-key path — **still supported**      |
+| `BAND_BASE_URL`                             | API base URL (default: `https://app.band.ai`) |
 | `TRANSPORT`                                    | `stdio` (default) or `sse`                        |
 | `HOST` / `PORT`                                | SSE bind host/port                                |
 
@@ -447,12 +447,12 @@ Legacy `.env` setups keep working unchanged:
 
 ```bash
 # Legacy, still supported
-THENVOI_API_KEY=your-api-key-here
-THENVOI_BASE_URL=https://app.thenvoi.com
+BAND_API_KEY=your-api-key-here
+BAND_BASE_URL=https://app.band.ai
 ```
 
-When both a scope-specific key (`THENVOI_USER_KEY` / `THENVOI_AGENT_KEY`) and
-`THENVOI_API_KEY` are set, the scope-specific key wins for its scope. The
+When both a scope-specific key (`BAND_USER_KEY` / `BAND_AGENT_KEY`) and
+`BAND_API_KEY` are set, the scope-specific key wins for its scope. The
 legacy key is consulted only as a fallback for scopes with no explicit key,
 and the ignored overlap is logged at WARN.
 
@@ -467,26 +467,26 @@ and the ignored overlap is logged at WARN.
 python --version
 
 # Verify the CLI is installed
-thenvoi-mcp --help
+band-mcp --help
 
 # Try running with debug mode
-THENVOI_LOG_LEVEL=debug thenvoi-mcp
+THENVOI_LOG_LEVEL=debug band-mcp
 ```
 
 ### Authentication Failures
 
 - Verify your API key is correct and not expired
-- Regenerate API key at [app.thenvoi.com/settings/api-keys](https://app.thenvoi.com/settings/api-keys)
+- Regenerate API key at [app.band.ai/settings/api-keys](https://app.band.ai/settings/api-keys)
 - Test API directly:
   ```bash
-  curl -H "Authorization: Bearer $THENVOI_API_KEY" \
-    https://app.thenvoi.com/api/v1/health
+  curl -H "Authorization: Bearer $BAND_API_KEY" \
+    https://app.band.ai/api/v1/health
   ```
 
 ### AI Assistant Not Detecting Tools
 
-1. Confirm `thenvoi-mcp` is on PATH: `which thenvoi-mcp`
-2. Test server manually: `THENVOI_API_KEY=... thenvoi-mcp`
+1. Confirm `band-mcp` is on PATH: `which band-mcp`
+2. Test server manually: `BAND_API_KEY=... band-mcp`
 3. Restart your AI assistant completely
 4. Check logs:
    ```bash
@@ -498,8 +498,8 @@ THENVOI_LOG_LEVEL=debug thenvoi-mcp
 
 | Issue                          | Solution                                                                                         |
 | ------------------------------ | ------------------------------------------------------------------------------------------------ |
-| "thenvoi-mcp command not found"| Install with `pip install band-mcp` or `uv tool install band-mcp`                              |
-| "API key invalid"              | Regenerate API key at[app.thenvoi.com/settings/api-keys](https://app.thenvoi.com/settings/api-keys) |
+| "band-mcp command not found"| Install with `pip install band-mcp` or `uv tool install band-mcp`                              |
+| "API key invalid"              | Regenerate API key at[app.band.ai/settings/api-keys](https://app.band.ai/settings/api-keys) |
 | "Connection refused"           | Check firewall settings and network connectivity                                                 |
 
 ## 💻 Development
@@ -507,7 +507,7 @@ THENVOI_LOG_LEVEL=debug thenvoi-mcp
 ### Project Structure
 
 ```
-thenvoi-mcp-server/
+band-mcp-server/
 ├── src/
 │   └── thenvoi_mcp/              # Main package
 │       ├── __init__.py            # Package initialization
@@ -546,11 +546,11 @@ thenvoi-mcp-server/
 
 ```bash
 # Clone the repository (with submodules for shared rules)
-git clone --recurse-submodules https://github.com/thenvoi/thenvoi-mcp
-cd thenvoi-mcp
+git clone --recurse-submodules https://github.com/thenvoi/band-mcp
+cd band-mcp
 
 # Copy environment template
-cp .env.example .env  # then edit and set THENVOI_API_KEY
+cp .env.example .env  # then edit and set BAND_API_KEY
 
 # Install with dev dependencies
 uv sync --extra dev
@@ -609,7 +609,7 @@ cd sdk_package && uv build
 
 # 5. Use local SDK in MCP project
 export UV_FIND_LINKS="/path/to/sdk-repo/sdk_package/dist/"
-cd /path/to/thenvoi-mcp
+cd /path/to/band-mcp
 uv lock && uv sync --all-extras
 ```
 
@@ -624,7 +624,7 @@ cp -r generated_sdk/* sdk_package/thenvoi_rest/
 cd sdk_package && rm -rf dist && uv build
 
 # 2. Clear uv cache and force reinstall
-cd /path/to/thenvoi-mcp
+cd /path/to/band-mcp
 uv cache clean --force thenvoi-rest
 uv lock --upgrade-package thenvoi-rest
 uv sync --all-extras
@@ -651,25 +651,25 @@ uv run pytest --cov=src/thenvoi_mcp --cov-report=html
 ## 📚 Resources
 
 - [Model Context Protocol Documentation](https://modelcontextprotocol.io)
-- [Thenvoi Platform](https://app.thenvoi.com)
+- [Band Platform](https://app.band.ai)
 - [uv Package Manager](https://docs.astral.sh/uv/)
 
 ### Using Context7 MCP for Documentation
 
-[Context7](https://github.com/upstash/context7) is an MCP server that provides up-to-date documentation for libraries and frameworks. It's highly recommended to use Context7 alongside Thenvoi MCP when developing—it helps your AI assistant fetch accurate, current documentation.
+[Context7](https://github.com/upstash/context7) is an MCP server that provides up-to-date documentation for libraries and frameworks. It's highly recommended to use Context7 alongside Band MCP when developing—it helps your AI assistant fetch accurate, current documentation.
 
 #### Adding Context7 to Your MCP Configuration
 
-Add Context7 to your existing MCP configuration alongside Thenvoi:
+Add Context7 to your existing MCP configuration alongside Band:
 
 ```json
 {
   "mcpServers": {
-    "thenvoi": {
-      "command": "thenvoi-mcp",
+    "band": {
+      "command": "band-mcp",
       "env": {
-        "THENVOI_API_KEY": "your_api_key_here",
-        "THENVOI_BASE_URL": "https://app.thenvoi.com"
+        "BAND_API_KEY": "your_api_key_here",
+        "BAND_BASE_URL": "https://app.band.ai"
       }
     },
     "context7": {
@@ -686,7 +686,7 @@ Add Context7 to your existing MCP configuration alongside Thenvoi:
 
 Once configured, you can ask your AI assistant to fetch documentation:
 
-- *"Look up the Thenvoi REST API documentation with Context7"*
+- *"Look up the Band REST API documentation with Context7"*
 
 Context7 will retrieve current documentation directly from official sources, ensuring your AI assistant has accurate information when helping you code.
 

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ python --version
 band-mcp --help
 
 # Try running with debug mode
-THENVOI_LOG_LEVEL=debug band-mcp
+BAND_LOG_LEVEL=debug band-mcp
 ```
 
 ### Authentication Failures

--- a/claude.md
+++ b/claude.md
@@ -1,10 +1,10 @@
-# Thenvoi MCP Server
+# Band MCP Server
 
-MCP (Model Context Protocol) server that connects AI assistants to the Thenvoi platform.
+MCP (Model Context Protocol) server that connects AI assistants to the Band platform.
 
 ## Core Features
 
-1. Connects AI assistants to Thenvoi's agent collaboration platform
+1. Connects AI assistants to Band's agent collaboration platform
 2. Supports dual transport modes: STDIO (IDE integration) and SSE (remote deployments)
 3. Conditional tool loading based on API key type (user vs agent)
 
@@ -32,7 +32,7 @@ def my_tool(ctx: AppContextType, param: str) -> str:
 - Use the shared logger: `from thenvoi_mcp.shared import logger`
 - All tools must use the `@mcp.tool()` decorator
 - Tools must accept `ctx: AppContextType` as the first parameter
-- Use `get_app_context(ctx).client` to access the Thenvoi API client
+- Use `get_app_context(ctx).client` to access the Band API client
 - Tools must return strings (success messages or JSON)
 
 ## Commands
@@ -42,7 +42,7 @@ def my_tool(ctx: AppContextType, param: str) -> str:
 uv sync
 
 # Run the server
-uv run thenvoi-mcp
+uv run band-mcp
 
 # Run unit tests
 uv run pytest tests/ --ignore=tests/integration/ -v
@@ -53,13 +53,13 @@ uv run pre-commit run --all-files
 
 ## Transport Modes
 
-- **STDIO** (default): `thenvoi-mcp` - For Cursor, Claude Desktop
-- **SSE**: `thenvoi-mcp --transport sse --port 3000` - For Docker, cloud deployments
+- **STDIO** (default): `band-mcp` - For Cursor, Claude Desktop
+- **SSE**: `band-mcp --transport sse --port 3000` - For Docker, cloud deployments
 
 ## Environment Variables
 
-- `THENVOI_API_KEY`: Required API key
-- `THENVOI_BASE_URL`: API base URL (default: https://app.thenvoi.com)
+- `BAND_API_KEY`: Required API key
+- `BAND_BASE_URL`: API base URL (default: https://app.band.ai)
 - `TRANSPORT`: stdio or sse (default: stdio)
 - `HOST`: SSE host (default: 127.0.0.1)
 - `PORT`: SSE port (default: 8000)

--- a/examples/langchain_agent.py
+++ b/examples/langchain_agent.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """
-LangChain agent that uses Thenvoi MCP tools with langchain-mcp-adapters.
+LangChain agent that uses Band MCP tools with langchain-mcp-adapters.
 
-This example shows how to use the Thenvoi MCP server with a LangChain
+This example shows how to use the Band MCP server with a LangChain
 agent using the newer create_agent pattern (built on LangGraph).
 
 Usage:
     export OPENAI_API_KEY="sk-..."
-    export THENVOI_API_KEY="thnv_..."
+    export BAND_API_KEY="thnv_..."
     uv run examples/langchain_agent.py
 """
 
@@ -30,31 +30,29 @@ logger = logging.getLogger(__name__)
 
 
 async def main() -> None:
-    """Run LangChain agent with Thenvoi MCP tools."""
-    if not os.getenv("OPENAI_API_KEY") or not os.getenv("THENVOI_API_KEY"):
-        logger.error("Error: Set OPENAI_API_KEY and THENVOI_API_KEY")
+    """Run LangChain agent with Band MCP tools."""
+    if not os.getenv("OPENAI_API_KEY") or not os.getenv("BAND_API_KEY"):
+        logger.error("Error: Set OPENAI_API_KEY and BAND_API_KEY")
         return
 
     project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
-    # Create MCP client that connects to Thenvoi server
+    # Create MCP client that connects to Band server
     client = MultiServerMCPClient(
         {
-            "thenvoi": {
+            "band": {
                 "command": "uv",
-                "args": ["--directory", project_root, "run", "thenvoi-mcp"],
+                "args": ["--directory", project_root, "run", "band-mcp"],
                 "transport": "stdio",
                 "env": {
-                    "THENVOI_API_KEY": os.getenv("THENVOI_API_KEY", ""),
-                    "THENVOI_BASE_URL": os.getenv(
-                        "THENVOI_BASE_URL", "https://app.thenvoi.com"
-                    ),
+                    "BAND_API_KEY": os.getenv("BAND_API_KEY", ""),
+                    "BAND_BASE_URL": os.getenv("BAND_BASE_URL", "https://app.band.ai"),
                 },
             },
         }
     )
 
-    logger.info("Loading tools from Thenvoi MCP server...")
+    logger.info("Loading tools from Band MCP server...")
     tools = await client.get_tools()
     logger.info(f"Loaded {len(tools)} tools!")
 

--- a/examples/langgraph_agent.py
+++ b/examples/langgraph_agent.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """
-LangGraph agent that uses Thenvoi MCP tools with langchain-mcp-adapters.
+LangGraph agent that uses Band MCP tools with langchain-mcp-adapters.
 
-This example shows how to use the Thenvoi MCP server with LangGraph
+This example shows how to use the Band MCP server with LangGraph
 using the MultiServerMCPClient from langchain-mcp-adapters.
 
 Usage:
     export OPENAI_API_KEY="sk-..."
-    export THENVOI_API_KEY="thnv_..."
+    export BAND_API_KEY="thnv_..."
     uv run examples/langgraph_agent.py
 """
 
@@ -32,31 +32,29 @@ logger = logging.getLogger(__name__)
 
 
 async def main() -> None:
-    """Run LangGraph agent with Thenvoi MCP tools."""
-    if not os.getenv("OPENAI_API_KEY") or not os.getenv("THENVOI_API_KEY"):
-        logger.error("Error: Set OPENAI_API_KEY and THENVOI_API_KEY")
+    """Run LangGraph agent with Band MCP tools."""
+    if not os.getenv("OPENAI_API_KEY") or not os.getenv("BAND_API_KEY"):
+        logger.error("Error: Set OPENAI_API_KEY and BAND_API_KEY")
         return
 
     project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
-    # Create MCP client that connects to Thenvoi server
+    # Create MCP client that connects to Band server
     client = MultiServerMCPClient(
         {
-            "thenvoi": {
+            "band": {
                 "command": "uv",
-                "args": ["--directory", project_root, "run", "thenvoi-mcp"],
+                "args": ["--directory", project_root, "run", "band-mcp"],
                 "transport": "stdio",
                 "env": {
-                    "THENVOI_API_KEY": os.getenv("THENVOI_API_KEY", ""),
-                    "THENVOI_BASE_URL": os.getenv(
-                        "THENVOI_BASE_URL", "https://app.thenvoi.com"
-                    ),
+                    "BAND_API_KEY": os.getenv("BAND_API_KEY", ""),
+                    "BAND_BASE_URL": os.getenv("BAND_BASE_URL", "https://app.band.ai"),
                 },
             },
         }
     )
 
-    logger.info("Loading tools from Thenvoi MCP server...")
+    logger.info("Loading tools from Band MCP server...")
     tools = await client.get_tools()
     logger.info(f"Loaded {len(tools)} tools!")
 

--- a/mcp_config_example.json
+++ b/mcp_config_example.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
-    "thenvoi": {
-      "command": "thenvoi-mcp",
+    "band": {
+      "command": "band-mcp",
       "args": [
         "--scope",
         "agent",
@@ -9,17 +9,17 @@
         "contacts"
       ],
       "env": {
-        "THENVOI_AGENT_KEY": "thnv_a_your_agent_key",
-        "THENVOI_USER_KEY": "thnv_u_your_user_key",
-        "THENVOI_BASE_URL": "https://app.thenvoi.com"
+        "BAND_AGENT_KEY": "thnv_a_your_agent_key",
+        "BAND_USER_KEY": "thnv_u_your_user_key",
+        "BAND_BASE_URL": "https://app.band.ai"
       }
     },
     "thenvoi_legacy": {
-      "_comment": "Legacy single-key setup. Still supported; prefer THENVOI_USER_KEY / THENVOI_AGENT_KEY for new deployments.",
-      "command": "thenvoi-mcp",
+      "_comment": "Legacy single-key setup. Still supported; prefer BAND_USER_KEY / BAND_AGENT_KEY for new deployments.",
+      "command": "band-mcp",
       "env": {
-        "THENVOI_API_KEY": "your_api_key_here",
-        "THENVOI_BASE_URL": "https://app.thenvoi.com"
+        "BAND_API_KEY": "your_api_key_here",
+        "BAND_BASE_URL": "https://app.band.ai"
       }
     }
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
-name = "thenvoi-mcp"
+name = "band-mcp"
 version = "1.3.1"
-description = "Model Context Protocol (MCP) server for Thenvoi integration"
+description = "Model Context Protocol (MCP) server for Band integration"
 readme = "README.md"
-authors = [{ name = "thenvoi" }]
+authors = [{ name = "Band" }]
 requires-python = ">=3.11"
 dependencies = [
     "mcp[cli]>=1.23.0",
@@ -49,6 +49,7 @@ examples = [
 ]
 
 [project.scripts]
+band-mcp = "thenvoi_mcp.server:run"
 thenvoi-mcp = "thenvoi_mcp.server:run"
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "band-mcp"
 version = "1.3.1"
 description = "Model Context Protocol (MCP) server for Band integration"
 readme = "README.md"
-authors = [{ name = "Band" }]
+authors = [{ name = "band.ai" }]
 requires-python = ">=3.11"
 dependencies = [
     "mcp[cli]>=1.23.0",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "release-type": "python",
   "packages": {
     ".": {
-      "package-name": "thenvoi-mcp",
+      "package-name": "band-mcp",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,

--- a/src/thenvoi_mcp/__init__.py
+++ b/src/thenvoi_mcp/__init__.py
@@ -1,4 +1,4 @@
-"""Thenvoi MCP Server - Model Context Protocol integration for Thenvoi."""
+"""Band MCP Server - Model Context Protocol integration for Band."""
 
 from thenvoi_mcp.config import settings
 

--- a/src/thenvoi_mcp/config.py
+++ b/src/thenvoi_mcp/config.py
@@ -1,4 +1,4 @@
-"""Configuration for thenvoi-mcp.
+"""Configuration for band-mcp.
 
 Phase 2 of INT-338 (INT-350) replaces the single-key `THENVOI_API_KEY` + prefix
 inference config with explicit dual credentials, `--scope` / `--tools` /
@@ -6,7 +6,7 @@ inference config with explicit dual credentials, `--scope` / `--tools` /
 retained as a fallback — existing deployments keep working.
 
 Resolution precedence per credential/field:
-    CLI flag > THENVOI_* env > BAND_* env > THENVOI_API_KEY (legacy only)
+    CLI flag > BAND_* env > THENVOI_* env > THENVOI_API_KEY (legacy only)
 
 `resolve_config(cli, env)` is pure — it takes a CLI-args-ish mapping and an
 environment mapping, and returns a `Config`. `validate(config)` raises
@@ -24,6 +24,7 @@ import difflib
 from dataclasses import dataclass, field
 from typing import Literal, Mapping, Sequence, cast
 
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 Scope = Literal["agent", "human"]
@@ -101,8 +102,14 @@ class Settings(BaseSettings):
     """
 
     # API configuration
-    thenvoi_api_key: str = ""
-    thenvoi_base_url: str = "https://app.thenvoi.com"
+    thenvoi_api_key: str = Field(
+        default="",
+        validation_alias=AliasChoices("BAND_API_KEY", "THENVOI_API_KEY"),
+    )
+    thenvoi_base_url: str = Field(
+        default="https://app.band.ai",
+        validation_alias=AliasChoices("BAND_BASE_URL", "THENVOI_BASE_URL"),
+    )
 
     # Transport configuration
     transport: Literal["stdio", "sse"] = "stdio"
@@ -230,7 +237,7 @@ def _resolve_list(
 ) -> list[str]:
     """Apply per-field precedence for list-valued settings.
 
-    Precedence: CLI > THENVOI_* env > BAND_* env > default.
+    Precedence: CLI > BAND_* env > THENVOI_* env > default.
 
     `explicit_empty` lets a caller pass `--tools ""` (empty CLI value) and have
     it override the env/default, matching the ticket's `--tools ""` -> []
@@ -242,10 +249,10 @@ def _resolve_list(
         not isinstance(cli_value, (list, tuple)) or len(cli_value) > 0
     ):
         return _normalize_list_value(cli_value)
-    if env_primary is not None:
-        return _normalize_list_value(env_primary)
     if env_alias is not None:
         return _normalize_list_value(env_alias)
+    if env_primary is not None:
+        return _normalize_list_value(env_primary)
     return list(default)
 
 
@@ -299,7 +306,7 @@ def _resolve_scalar(
     env_primary: str | None,
     env_alias: str | None,
 ) -> str | None:
-    """CLI > THENVOI_* > BAND_* > None. Empty strings count as unset."""
+    """CLI > BAND_* > THENVOI_* > None. Empty strings count as unset."""
     for candidate in (cli_value, env_primary, env_alias):
         if candidate is not None and candidate != "":
             return candidate
@@ -336,17 +343,17 @@ def resolve_config(
         cli.get("user_key")
         if isinstance(cli.get("user_key"), str) or cli.get("user_key") is None
         else None,  # type: ignore[arg-type]
-        env.get("THENVOI_USER_KEY"),
         env.get("BAND_USER_KEY"),
+        env.get("THENVOI_USER_KEY"),
     )
     agent_key = _resolve_scalar(
         cli.get("agent_key")
         if isinstance(cli.get("agent_key"), str) or cli.get("agent_key") is None
         else None,  # type: ignore[arg-type]
-        env.get("THENVOI_AGENT_KEY"),
         env.get("BAND_AGENT_KEY"),
+        env.get("THENVOI_AGENT_KEY"),
     )
-    legacy_key_raw = env.get("THENVOI_API_KEY")
+    legacy_key_raw = env.get("BAND_API_KEY") or env.get("THENVOI_API_KEY")
     legacy_key: str | None = legacy_key_raw if legacy_key_raw else None
 
     # --- Room id -----------------------------------------------------------
@@ -354,8 +361,8 @@ def resolve_config(
         cli.get("room_id")
         if isinstance(cli.get("room_id"), str) or cli.get("room_id") is None
         else None,  # type: ignore[arg-type]
-        env.get("THENVOI_MCP_ROOM_ID"),
         env.get("BAND_MCP_ROOM_ID"),
+        env.get("THENVOI_MCP_ROOM_ID"),
     )
 
     warnings: list[ConfigWarning] = []
@@ -366,8 +373,8 @@ def resolve_config(
         cli_scope
         if cli_scope is None or isinstance(cli_scope, (str, list, tuple))
         else None,  # type: ignore[arg-type]
-        env.get("THENVOI_MCP_SCOPE"),
         env.get("BAND_MCP_SCOPE"),
+        env.get("THENVOI_MCP_SCOPE"),
         default=list(DEFAULT_SCOPE),
         explicit_empty=False,
     )
@@ -392,8 +399,8 @@ def resolve_config(
         cli_tools
         if cli_tools is None or isinstance(cli_tools, (str, list, tuple))
         else None,  # type: ignore[arg-type]
-        env.get("THENVOI_MCP_TOOLS"),
         env.get("BAND_MCP_TOOLS"),
+        env.get("THENVOI_MCP_TOOLS"),
         default=list(DEFAULT_TOOLS),
         explicit_empty=explicit_empty,
     )
@@ -426,8 +433,8 @@ def resolve_config(
                     value="legacy_key",
                     did_you_mean=None,
                     message=(
-                        "THENVOI_API_KEY is set but scope-specific keys "
-                        "(THENVOI_USER_KEY / THENVOI_AGENT_KEY) take precedence; "
+                        "A legacy API key is set but scope-specific keys"
+                        "(BAND_USER_KEY / BAND_AGENT_KEY) take precedence;"
                         "legacy key ignored for overlapping scope(s)."
                     ),
                 )
@@ -464,14 +471,14 @@ def validate(config: Config) -> None:
         if config.user_key is None and not legacy_human:
             missing.append(
                 "human scope requested but no user credential available "
-                "(set --user-key / THENVOI_USER_KEY / BAND_USER_KEY, or use a "
+                "(set --user-key / BAND_USER_KEY / THENVOI_USER_KEY, or use a "
                 "human-capable THENVOI_API_KEY)"
             )
     if "agent" in config.scope:
         if config.agent_key is None and not legacy_agent:
             missing.append(
                 "agent scope requested but no agent credential available "
-                "(set --agent-key / THENVOI_AGENT_KEY / BAND_AGENT_KEY, or use an "
+                "(set --agent-key / BAND_AGENT_KEY / THENVOI_AGENT_KEY, or use an "
                 "agent-capable THENVOI_API_KEY)"
             )
 

--- a/src/thenvoi_mcp/config.py
+++ b/src/thenvoi_mcp/config.py
@@ -249,10 +249,10 @@ def _resolve_list(
         not isinstance(cli_value, (list, tuple)) or len(cli_value) > 0
     ):
         return _normalize_list_value(cli_value)
-    if env_alias is not None:
-        return _normalize_list_value(env_alias)
     if env_primary is not None:
         return _normalize_list_value(env_primary)
+    if env_alias is not None:
+        return _normalize_list_value(env_alias)
     return list(default)
 
 

--- a/src/thenvoi_mcp/server.py
+++ b/src/thenvoi_mcp/server.py
@@ -139,7 +139,7 @@ def health_check(ctx: AppContextType) -> str:
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
-        description="Thenvoi MCP Server - Connect AI agents to Thenvoi platform",
+        description="Band MCP Server - Connect AI agents to Band platform",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Transport Modes:
@@ -150,20 +150,20 @@ Transport Modes:
           Runs as a persistent HTTP service with Server-Sent Events.
 
 Examples:
-  thenvoi-mcp                                 # Run with STDIO (default)
-  thenvoi-mcp --transport sse                 # Run as HTTP server on 127.0.0.1:8000
-  thenvoi-mcp --scope agent,human             # Serve both scopes
-  thenvoi-mcp --scope agent --tools contacts  # Agent + opt-in contacts tools
-  thenvoi-mcp --scope agent --room-id r_123   # Pin to a single room
+  band-mcp                                    # Run with STDIO (default)
+  band-mcp --transport sse                    # Run as HTTP server on 127.0.0.1:8000
+  band-mcp --scope agent,human                # Serve both scopes
+  band-mcp --scope agent --tools contacts     # Agent + opt-in contacts tools
+  band-mcp --scope agent --room-id r_123      # Pin to a single room
 
 Environment Variables:
-  THENVOI_USER_KEY / BAND_USER_KEY      User (human scope) API key
-  THENVOI_AGENT_KEY / BAND_AGENT_KEY    Agent scope API key
-  THENVOI_MCP_SCOPE / BAND_MCP_SCOPE    Comma-separated scopes (default: agent)
-  THENVOI_MCP_TOOLS / BAND_MCP_TOOLS    Opt-in tool groups: contacts, memory
-  THENVOI_MCP_ROOM_ID / BAND_MCP_ROOM_ID  Optional pinned room id
+  BAND_USER_KEY / THENVOI_USER_KEY      User (human scope) API key
+  BAND_AGENT_KEY / THENVOI_AGENT_KEY    Agent scope API key
+  BAND_MCP_SCOPE / THENVOI_MCP_SCOPE    Comma-separated scopes (default: agent)
+  BAND_MCP_TOOLS / THENVOI_MCP_TOOLS    Opt-in tool groups: contacts, memory
+  BAND_MCP_ROOM_ID / THENVOI_MCP_ROOM_ID  Optional pinned room id
   THENVOI_API_KEY       Legacy single-key path (still supported as fallback)
-  THENVOI_BASE_URL      Base URL for Thenvoi API (default: https://app.thenvoi.com)
+  BAND_BASE_URL         Base URL for Band API (default: https://app.band.ai)
   TRANSPORT             Transport mode: stdio or sse (default: stdio)
   HOST                  Host to bind for SSE mode (default: 127.0.0.1)
   PORT                  Port to bind for SSE mode (default: 8000)
@@ -173,7 +173,7 @@ Environment Variables:
     parser.add_argument(
         "--version",
         action="version",
-        version=f"thenvoi-mcp {__version__}",
+        version=f"band-mcp {__version__}",
     )
 
     parser.add_argument("--user-key", dest="user_key", type=str, default=None)
@@ -337,7 +337,7 @@ def run() -> None:
     if args.port is not None:
         mcp.settings.port = args.port
 
-    logger.info("Starting thenvoi-mcp-server v%s", __version__)
+    logger.info("Starting band-mcp-server v%s", __version__)
     logger.info("Base URL: %s", settings.thenvoi_base_url)
     logger.info("API key type: %s", key_type)
     logger.info("Resolved scope: %s", config.scope or "<none>")

--- a/src/thenvoi_mcp/server.py
+++ b/src/thenvoi_mcp/server.py
@@ -162,7 +162,7 @@ Environment Variables:
   BAND_MCP_SCOPE / THENVOI_MCP_SCOPE    Comma-separated scopes (default: agent)
   BAND_MCP_TOOLS / THENVOI_MCP_TOOLS    Opt-in tool groups: contacts, memory
   BAND_MCP_ROOM_ID / THENVOI_MCP_ROOM_ID  Optional pinned room id
-  THENVOI_API_KEY       Legacy single-key path (still supported as fallback)
+  BAND_API_KEY / THENVOI_API_KEY      Legacy single-key path (still supported as fallback)
   BAND_BASE_URL         Base URL for Band API (default: https://app.band.ai)
   TRANSPORT             Transport mode: stdio or sse (default: stdio)
   HOST                  Host to bind for SSE mode (default: 127.0.0.1)
@@ -290,8 +290,8 @@ def run() -> None:
         # that CLI is empty AND no new-style env vars were set.
         if _is_pure_legacy_invocation(args, config):
             logger.info(
-                "Proceeding via legacy THENVOI_API_KEY path (no new-style "
-                "credentials or scope supplied)."
+                "Proceeding via legacy BAND_API_KEY/THENVOI_API_KEY path "
+                "(no new-style credentials or scope supplied)."
             )
         else:
             logger.error("Configuration error: %s", exc)

--- a/src/thenvoi_mcp/shared.py
+++ b/src/thenvoi_mcp/shared.py
@@ -248,14 +248,14 @@ def set_pending_config(config: Config) -> None:
 @asynccontextmanager
 async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
     """Lifespan context manager for MCP server."""
-    logger.info("Initializing Thenvoi API client")
+    logger.info("Initializing Band API client")
     app_context = build_app_context(_pending_config)
-    logger.info("Thenvoi MCP server lifespan started successfully")
+    logger.info("Band MCP server lifespan started successfully")
 
     try:
         yield app_context
     finally:
-        logger.info("Thenvoi MCP server lifespan shutdown complete")
+        logger.info("Band MCP server lifespan shutdown complete")
 
 
 def get_app_context(ctx: AppContextType) -> AppContext:
@@ -283,7 +283,7 @@ def get_human_tools(ctx: AppContextType) -> Any:
     app_ctx = get_app_context(ctx)
     if app_ctx.human_tools is None:
         logger.warning(
-            "get_human_tools(): HumanTools not available. Ensure the Thenvoi "
+            "get_human_tools(): HumanTools not available. Ensure the Band "
             "SDK (INT-349) is installed and a human credential is configured."
         )
     return app_ctx.human_tools
@@ -374,7 +374,7 @@ if (
     )
 
 mcp = FastMCP(
-    name="thenvoi-mcp-server",
+    name="band-mcp-server",
     lifespan=app_lifespan,
     host=settings.host,
     port=settings.port,

--- a/src/thenvoi_mcp/shared.py
+++ b/src/thenvoi_mcp/shared.py
@@ -9,7 +9,7 @@ working; Phase 4 (INT-352) deletes those and `client` goes with them.
 
 HumanTools / AgentTools coordination with INT-349
 -------------------------------------------------
-The SDK's `HumanTools` class lands in Phase 1 (INT-349) in `thenvoi-sdk-python`
+The SDK's `HumanTools` class lands in Phase 1 (INT-349) in `band-sdk-python`
 and is not yet available in this environment (the repo depends on
 `thenvoi-client-rest`, which is the Fern-generated REST client only).
 `get_human_tools()` / `get_agent_tools()` import `HumanTools` / `AgentTools`

--- a/src/thenvoi_mcp/tools/agent/agent_messages.py
+++ b/src/thenvoi_mcp/tools/agent/agent_messages.py
@@ -1,6 +1,7 @@
 import json
 import logging
-from typing import Any, Dict, List, Literal, Optional
+import re
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from thenvoi_rest import (
     ChatMessageRequest,
@@ -11,6 +12,44 @@ from thenvoi_rest.core.api_error import ApiError
 from thenvoi_mcp.shared import AppContextType, get_app_context, mcp, serialize_response
 
 logger = logging.getLogger(__name__)
+
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
+)
+
+
+def _looks_like_uuid(value: Any) -> bool:
+    """True if value is a string matching the canonical UUID form."""
+    return isinstance(value, str) and bool(_UUID_RE.match(value))
+
+
+def _build_participant_index(client: Any, chat_id: str) -> Dict[str, Any]:
+    """Map a chat room's participants by every name-like key (lowercased, @-stripped).
+
+    Indexes name, username, display_name and handle so a caller can resolve a
+    participant by any of them — used to turn human-friendly names or handles
+    into the platform participant IDs that mentions require.
+    """
+    participants_response = client.agent_api_participants.list_agent_chat_participants(
+        chat_id=chat_id
+    )
+    index: Dict[str, Any] = {}
+    for p in participants_response.data or []:
+        for attr in ("name", "username", "display_name", "handle"):
+            val = getattr(p, attr, None)
+            if isinstance(val, str) and val:
+                index[val.lower().lstrip("@")] = p
+    return index
+
+
+def _participant_display_name(participant: Any) -> str:
+    """Best display name for a participant, without the @ prefix."""
+    return (
+        getattr(participant, "name", None)
+        or getattr(participant, "username", None)
+        or getattr(participant, "display_name", None)
+        or "Unknown"
+    )
 
 
 @mcp.tool()
@@ -156,7 +195,7 @@ def create_agent_chat_message(
     chat_id: str,
     content: str,
     recipients: Optional[str] = None,
-    mentions: Optional[str] = None,
+    mentions: Optional[Union[str, list]] = None,
 ) -> str:
     """Send a text message in a chat room.
 
@@ -169,11 +208,15 @@ def create_agent_chat_message(
         Provide comma-separated names. The tool resolves names to IDs automatically.
         Example: recipients="weather agent,sarah"
 
-    Option 2 - Use `mentions` (for libraries with caching):
-        Provide a JSON array with pre-resolved IDs.
-        Example: mentions='[{"id": "uuid-123", "name": "weather agent"}]'
+    Option 2 - Use `mentions`:
+        Provide a list of mentions — either as a native list or a JSON-encoded
+        string. Each item may be a handle/name string, or an object with any of
+        id / handle / name. Handles and names are resolved to participant IDs
+        automatically; items that already carry a UUID `id` skip resolution.
+        Example: mentions=[{"id": "uuid-123", "name": "weather agent"}]
+        Example: mentions=["weather agent", "@sarah"]
 
-    If both are provided, `mentions` takes precedence (no API call needed).
+    If both are provided, `mentions` takes precedence.
 
     For event-type messages (tool_call, tool_result, thought, error, etc.),
     use create_agent_chat_event instead.
@@ -184,9 +227,11 @@ def create_agent_chat_message(
         recipients: Comma-separated participant names to tag (LLM-friendly).
                    Example: "weather agent,sarah,mike"
                    Names are resolved to IDs via list_agent_chat_participants.
-        mentions: JSON array of mentions with pre-resolved IDs (for libraries).
-                 Format: [{"id": "uuid", "name": "display_name"}, ...]
-                 When provided, skips name resolution (more efficient).
+        mentions: List of mentions, as a native list or a JSON-encoded string.
+                 Items may be handle/name strings or objects with id/handle/name.
+                 Format: [{"id": "uuid", "name": "display_name"}, ...] or
+                 ["handle-or-name", ...]. Handles/names are resolved to IDs;
+                 UUID ids are used as-is.
 
     Returns:
         JSON string containing the created message details.
@@ -195,11 +240,14 @@ def create_agent_chat_message(
         # LLM usage (names):
         create_agent_chat_message(chat_id="123", content="Hello!", recipients="weather agent")
 
+        # LLM usage (mentions as a list of handles):
+        create_agent_chat_message(chat_id="123", content="Hello!", mentions=["weather agent"])
+
         # Library usage (pre-resolved IDs):
         create_agent_chat_message(
             chat_id="123",
             content="Hello!",
-            mentions='[{"id": "uuid-456", "name": "weather agent"}]'
+            mentions=[{"id": "uuid-456", "name": "weather agent"}]
         )
     """
     logger.debug("Creating message in chat: %s", chat_id)
@@ -207,18 +255,72 @@ def create_agent_chat_message(
 
     mentions_list: List[ChatMessageRequestMentionsItem] = []
 
-    # Option 1: Pre-resolved mentions provided (efficient path for libraries)
+    # Option 1: mentions provided (native list OR JSON-encoded string).
     if mentions:
-        try:
-            parsed_mentions = json.loads(mentions)
-            mentions_list = [
-                ChatMessageRequestMentionsItem(id=m["id"], name=m["name"])
-                for m in parsed_mentions
-            ]
-        except json.JSONDecodeError as e:
-            return f"Error: Invalid JSON for mentions: {str(e)}"
-        except KeyError as e:
-            return f"Error: Missing required field in mentions: {str(e)}"
+        if isinstance(mentions, str):
+            try:
+                parsed_mentions = json.loads(mentions)
+            except json.JSONDecodeError as e:
+                return (
+                    f"Error: Invalid JSON for mentions: {str(e)}. Pass a native "
+                    f'list like [{{"id": "uuid", "name": "display_name"}}] or '
+                    f"[\"handle\"], or use recipients='name1,name2'."
+                )
+        else:
+            parsed_mentions = mentions
+
+        if not isinstance(parsed_mentions, list):
+            return (
+                f"Error: mentions must be a list of mention objects or handles, "
+                f"got {type(parsed_mentions).__name__}."
+            )
+
+        # Split into pre-resolved (UUID-id objects) and items needing lookup
+        # (handle/name strings, or objects whose id is a handle, not a UUID).
+        needs_resolution: List[Any] = []
+        for m in parsed_mentions:
+            if isinstance(m, dict) and _looks_like_uuid(m.get("id")):
+                mentions_list.append(
+                    ChatMessageRequestMentionsItem(
+                        id=m["id"], name=m.get("name") or "Unknown"
+                    )
+                )
+            else:
+                needs_resolution.append(m)
+
+        if needs_resolution:
+            index = _build_participant_index(client, chat_id)
+            not_found: List[str] = []
+            for m in needs_resolution:
+                if isinstance(m, str):
+                    key = m
+                elif isinstance(m, dict):
+                    key = m.get("handle") or m.get("name") or m.get("id") or ""
+                else:
+                    not_found.append(str(m))
+                    continue
+                participant = index.get(str(key).lower().lstrip("@"))
+                if participant:
+                    mentions_list.append(
+                        ChatMessageRequestMentionsItem(
+                            id=participant.id,
+                            name=_participant_display_name(participant),
+                        )
+                    )
+                else:
+                    not_found.append(str(key))
+
+            if not_found:
+                return (
+                    f"Error: Could not resolve mentions: {', '.join(not_found)}. "
+                    f"Available participants: {', '.join(index.keys())}"
+                )
+
+        if not mentions_list:
+            return (
+                "Error: mentions resolved to an empty list. Provide at least one "
+                "valid mention (handle, name, or {id, name})."
+            )
 
     # Option 2: Resolve names to IDs (LLM-friendly path)
     elif recipients:
@@ -230,35 +332,18 @@ def create_agent_chat_message(
             return "Error: recipients cannot be empty"
 
         # Fetch participants to map names to IDs
-        participants_response = (
-            client.agent_api_participants.list_agent_chat_participants(chat_id=chat_id)
-        )
-        participants = participants_response.data
-
-        # Build name -> participant mapping (case-insensitive)
-        name_to_participant: Dict[str, Any] = {}
-        for p in participants:
-            # Agent participants have 'name' field
-            if hasattr(p, "name") and p.name:
-                name_to_participant[p.name.lower()] = p
-            # User participants may have 'username' or 'display_name'
-            if hasattr(p, "username") and p.username:
-                name_to_participant[p.username.lower()] = p
-            if hasattr(p, "display_name") and p.display_name:
-                name_to_participant[p.display_name.lower()] = p
+        name_to_participant = _build_participant_index(client, chat_id)
 
         # Resolve names to mentions
-        not_found: List[str] = []
+        not_found = []
         for name in recipient_names:
-            participant = name_to_participant.get(name)
+            participant = name_to_participant.get(name.lstrip("@"))
             if participant:
-                display_name = (
-                    getattr(participant, "name", None)
-                    or getattr(participant, "username", None)
-                    or getattr(participant, "display_name", "Unknown")
-                )
                 mentions_list.append(
-                    ChatMessageRequestMentionsItem(id=participant.id, name=display_name)
+                    ChatMessageRequestMentionsItem(
+                        id=participant.id,
+                        name=_participant_display_name(participant),
+                    )
                 )
             else:
                 not_found.append(name)
@@ -274,7 +359,7 @@ def create_agent_chat_message(
     else:
         return (
             f"Error: Missing recipients or mentions. To send a message, specify who to tag. "
-            f'Use recipients=\'name1,name2\' (names) or mentions=\'[{{"id":"uuid","name":"display_name"}}]\' (IDs). '
+            f'Use recipients=\'name1,name2\' (names) or mentions=[{{"id":"uuid","name":"display_name"}}] (IDs). '
             f"Call list_agent_chat_participants(chat_id='{chat_id}') to see available participants."
         )
 

--- a/src/thenvoi_mcp/tools/registrar.py
+++ b/src/thenvoi_mcp/tools/registrar.py
@@ -421,7 +421,7 @@ def register_tools(mcp: FastMCP, config: Config) -> None:
         from thenvoi.runtime.tools import iter_tool_definitions  # type: ignore[import-not-found]
     except Exception as exc:  # pragma: no cover - import-time guard
         logger.warning(
-            "register_tools(): Thenvoi SDK not available — skipping SDK-driven "
+            "register_tools(): Band SDK not available — skipping SDK-driven "
             "tool registration. Legacy handwritten handlers will still serve "
             "traffic. (%s)",
             exc,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Pytest configuration for thenvoi-mcp tests.
 
-Fixtures from thenvoi-testing-python are auto-loaded via pytest entry point.
+Fixtures from band-testing-python are auto-loaded via pytest entry point.
 We override mock_api_client to add v0.0.4 split namespace properties.
 """
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -197,10 +197,12 @@ class TestCreateAgentChatMessage:
         assert parsed["data"]["id"] == "msg-789"
 
     def test_creates_message_with_mentions(self, mock_ctx, mock_agent_api):
-        """Test creating a message using pre-resolved mentions."""
+        """Test creating a message using pre-resolved mentions (UUID ids skip resolution)."""
         chat_id = "chat-123"
         content = "Hello!"
-        mentions = '[{"id": "agent-456", "name": "Weather Agent"}]'
+        mentions = (
+            '[{"id": "11111111-1111-4111-8111-111111111111", "name": "Weather Agent"}]'
+        )
         message = factory.chat_message(id="msg-789", content=content)
         mock_agent_api.create_agent_chat_message.return_value = factory.response(
             message
@@ -219,7 +221,9 @@ class TestCreateAgentChatMessage:
     def test_mentions_takes_precedence_over_recipients(self, mock_ctx, mock_agent_api):
         """Test that mentions takes precedence when both are provided."""
         chat_id = "chat-123"
-        mentions = '[{"id": "agent-456", "name": "Weather Agent"}]'
+        mentions = (
+            '[{"id": "11111111-1111-4111-8111-111111111111", "name": "Weather Agent"}]'
+        )
         message = factory.chat_message(id="msg-789")
         mock_agent_api.create_agent_chat_message.return_value = factory.response(
             message
@@ -315,8 +319,11 @@ class TestCreateAgentChatMessage:
 
         mock_agent_api.create_agent_chat_message.assert_called_once()
 
-    def test_returns_error_on_mentions_missing_key(self, mock_ctx, mock_agent_api):
-        """Test error when mentions JSON is valid but missing required fields."""
+    def test_unresolvable_mention_returns_error(self, mock_ctx, mock_agent_api):
+        """A mention whose id is not a UUID and matches no participant errors clearly."""
+        mock_agent_api.list_agent_chat_participants.return_value = (
+            factory.list_response([factory.chat_participant(name="Existing Agent")])
+        )
         result = create_agent_chat_message(
             mock_ctx,
             chat_id="chat-123",
@@ -324,7 +331,85 @@ class TestCreateAgentChatMessage:
             mentions='[{"id": "agent-456"}]',
         )
         assert "Error" in result
-        assert "Missing required field in mentions" in result
+        assert "Could not resolve mentions" in result
+
+    def test_mentions_accepts_native_list_of_objects(self, mock_ctx, mock_agent_api):
+        """A native Python list of UUID-id objects is accepted without resolution."""
+        message = factory.chat_message(id="msg-789")
+        mock_agent_api.create_agent_chat_message.return_value = factory.response(
+            message
+        )
+
+        result = create_agent_chat_message(
+            mock_ctx,
+            chat_id="chat-123",
+            content="Hello!",
+            mentions=[
+                {"id": "11111111-1111-4111-8111-111111111111", "name": "Weather Agent"}
+            ],
+        )
+
+        mock_agent_api.list_agent_chat_participants.assert_not_called()
+        mock_agent_api.create_agent_chat_message.assert_called_once()
+        assert json.loads(result)["data"]["id"] == "msg-789"
+
+    def test_mentions_accepts_native_list_of_handles(self, mock_ctx, mock_agent_api):
+        """A native list of handle strings is resolved to participant IDs."""
+        participant = factory.chat_participant(id="agent-1", name="Weather Agent")
+        mock_agent_api.list_agent_chat_participants.return_value = (
+            factory.list_response([participant])
+        )
+        message = factory.chat_message(id="msg-789")
+        mock_agent_api.create_agent_chat_message.return_value = factory.response(
+            message
+        )
+
+        create_agent_chat_message(
+            mock_ctx,
+            chat_id="chat-123",
+            content="Hello!",
+            mentions=["Weather Agent"],
+        )
+
+        mock_agent_api.list_agent_chat_participants.assert_called_once_with(
+            chat_id="chat-123"
+        )
+        mentions = mock_agent_api.create_agent_chat_message.call_args.kwargs[
+            "message"
+        ].mentions
+        assert len(mentions) == 1
+        assert mentions[0].id == "agent-1"
+
+    def test_mentions_json_string_list_of_handles(self, mock_ctx, mock_agent_api):
+        """A JSON-encoded list of handle strings resolves without crashing on m['id']."""
+        participant = factory.chat_participant(id="agent-1", name="Weather Agent")
+        mock_agent_api.list_agent_chat_participants.return_value = (
+            factory.list_response([participant])
+        )
+        message = factory.chat_message(id="msg-789")
+        mock_agent_api.create_agent_chat_message.return_value = factory.response(
+            message
+        )
+
+        result = create_agent_chat_message(
+            mock_ctx,
+            chat_id="chat-123",
+            content="Hello!",
+            mentions='["Weather Agent"]',
+        )
+
+        assert json.loads(result)["data"]["id"] == "msg-789"
+
+    def test_mentions_object_not_array_errors(self, mock_ctx, mock_agent_api):
+        """A JSON object (not an array) for mentions returns a clear error, no crash."""
+        result = create_agent_chat_message(
+            mock_ctx,
+            chat_id="chat-123",
+            content="Hello!",
+            mentions='{"id": "x", "name": "y"}',
+        )
+        assert "Error" in result
+        assert "must be a list" in result
 
     def test_returns_error_on_empty_recipients_string(self, mock_ctx, mock_agent_api):
         """Test error when recipients is whitespace/commas only."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,7 +1,7 @@
 """Unit tests for `thenvoi_mcp.config`.
 
 Covers Phase 2 (INT-350) acceptance criteria:
-- Precedence per slot: CLI > THENVOI_* > BAND_* > THENVOI_API_KEY (legacy only).
+- Precedence per slot: CLI > BAND_* > THENVOI_* > THENVOI_API_KEY (legacy only).
 - Scope-specific key wins; legacy is fallback + emits warning when masked.
 - `--scope` / `--tools` parsing (comma-separated, repeatable, explicit empty).
 - Unknown values produce warnings with `did_you_mean` and are dropped.
@@ -100,12 +100,12 @@ def test_user_key_cli_beats_thenvoi_env():
     assert cfg.user_key == "cli_user"
 
 
-def test_user_key_thenvoi_beats_band():
+def test_user_key_band_beats_thenvoi():
     cfg = resolve_config(
         cli={},
         env={"THENVOI_USER_KEY": "env_thenvoi", "BAND_USER_KEY": "env_band"},
     )
-    assert cfg.user_key == "env_thenvoi"
+    assert cfg.user_key == "env_band"
 
 
 def test_user_key_band_when_only_band_set():
@@ -119,7 +119,7 @@ def test_user_key_none_when_nothing_set():
 
 
 def test_agent_key_precedence_chain():
-    # CLI beats THENVOI_* beats BAND_*
+    # CLI beats BAND_* beats THENVOI_*
     cfg = resolve_config(
         cli={"agent_key": "cli_a"},
         env={"THENVOI_AGENT_KEY": "env_t", "BAND_AGENT_KEY": "env_b"},
@@ -129,13 +129,18 @@ def test_agent_key_precedence_chain():
     cfg = resolve_config(
         cli={}, env={"THENVOI_AGENT_KEY": "env_t", "BAND_AGENT_KEY": "env_b"}
     )
-    assert cfg.agent_key == "env_t"
+    assert cfg.agent_key == "env_b"
 
     cfg = resolve_config(cli={}, env={"BAND_AGENT_KEY": "env_b"})
     assert cfg.agent_key == "env_b"
 
 
-def test_legacy_key_only_from_thenvoi_api_key():
+def test_legacy_key_from_band_api_key():
+    cfg = resolve_config(cli={}, env={"BAND_API_KEY": "band_u_abc"})
+    assert cfg.legacy_key == "band_u_abc"
+
+
+def test_legacy_key_falls_back_to_thenvoi_api_key():
     cfg = resolve_config(cli={}, env={"THENVOI_API_KEY": "thnv_u_abc"})
     assert cfg.legacy_key == "thnv_u_abc"
     # legacy doesn't populate user_key/agent_key directly
@@ -217,7 +222,7 @@ def test_room_id_precedence():
     cfg = resolve_config(
         cli={}, env={"THENVOI_MCP_ROOM_ID": "env_t", "BAND_MCP_ROOM_ID": "env_b"}
     )
-    assert cfg.room_id == "env_t"
+    assert cfg.room_id == "env_b"
 
     cfg = resolve_config(cli={}, env={"BAND_MCP_ROOM_ID": "env_b"})
     assert cfg.room_id == "env_b"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -267,12 +267,12 @@ def test_scope_precedence_cli_over_env():
     assert cfg.scope == ["human"]
 
 
-def test_scope_thenvoi_env_beats_band_env():
+def test_scope_band_env_beats_thenvoi_env():
     cfg = resolve_config(
         cli={},
         env={"THENVOI_MCP_SCOPE": "human", "BAND_MCP_SCOPE": "agent"},
     )
-    assert cfg.scope == ["human"]
+    assert cfg.scope == ["agent"]
 
 
 def test_scope_band_env_when_no_thenvoi():
@@ -335,7 +335,7 @@ def test_tools_precedence():
     cfg = resolve_config(
         cli={}, env={"THENVOI_MCP_TOOLS": "contacts", "BAND_MCP_TOOLS": "memory"}
     )
-    assert cfg.tools == ["contacts"]
+    assert cfg.tools == ["memory"]
 
     cfg = resolve_config(cli={}, env={"BAND_MCP_TOOLS": "memory"})
     assert cfg.tools == ["memory"]

--- a/uv.lock
+++ b/uv.lock
@@ -44,6 +44,100 @@ wheels = [
 ]
 
 [[package]]
+name = "band-mcp"
+version = "1.3.1"
+source = { editable = "." }
+dependencies = [
+    { name = "mcp", extra = ["cli"] },
+    { name = "pydantic-settings" },
+    { name = "thenvoi-client-rest" },
+    { name = "uvicorn" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "band-testing-python" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+    { name = "python-dotenv" },
+    { name = "respx" },
+]
+examples = [
+    { name = "langchain" },
+    { name = "langchain-core" },
+    { name = "langchain-mcp-adapters" },
+    { name = "langchain-openai" },
+    { name = "langgraph" },
+    { name = "python-dotenv" },
+]
+langchain = [
+    { name = "langchain" },
+    { name = "langchain-core" },
+    { name = "langchain-mcp-adapters" },
+    { name = "langchain-openai" },
+    { name = "python-dotenv" },
+]
+langgraph = [
+    { name = "langchain-core" },
+    { name = "langchain-mcp-adapters" },
+    { name = "langchain-openai" },
+    { name = "langgraph" },
+    { name = "python-dotenv" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "commitizen" },
+    { name = "pre-commit" },
+    { name = "pydantic-settings" },
+    { name = "pyrefly" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "band-testing-python", marker = "extra == 'dev'", specifier = ">=0.1.4" },
+    { name = "langchain", marker = "extra == 'examples'", specifier = ">=0.3.0" },
+    { name = "langchain", marker = "extra == 'langchain'", specifier = ">=0.3.0" },
+    { name = "langchain-core", marker = "extra == 'examples'", specifier = ">=1.2.5" },
+    { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=1.2.5" },
+    { name = "langchain-core", marker = "extra == 'langgraph'", specifier = ">=1.2.5" },
+    { name = "langchain-mcp-adapters", marker = "extra == 'examples'", specifier = ">=0.1.0" },
+    { name = "langchain-mcp-adapters", marker = "extra == 'langchain'", specifier = ">=0.1.0" },
+    { name = "langchain-mcp-adapters", marker = "extra == 'langgraph'", specifier = ">=0.1.0" },
+    { name = "langchain-openai", marker = "extra == 'examples'", specifier = ">=0.2.0" },
+    { name = "langchain-openai", marker = "extra == 'langchain'", specifier = ">=0.2.0" },
+    { name = "langchain-openai", marker = "extra == 'langgraph'", specifier = ">=0.2.0" },
+    { name = "langgraph", marker = "extra == 'examples'", specifier = ">=0.2.0" },
+    { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=0.2.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.23.0" },
+    { name = "pydantic-settings", specifier = ">=2.1.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
+    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.12.0" },
+    { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "python-dotenv", marker = "extra == 'examples'", specifier = ">=1.0.0" },
+    { name = "python-dotenv", marker = "extra == 'langchain'", specifier = ">=1.0.0" },
+    { name = "python-dotenv", marker = "extra == 'langgraph'", specifier = ">=1.0.0" },
+    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.20.0" },
+    { name = "thenvoi-client-rest", specifier = ">=0.0.4" },
+    { name = "uvicorn", specifier = ">=0.30.0" },
+]
+provides-extras = ["dev", "langgraph", "langchain", "examples"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "commitizen", specifier = ">=3.13.0" },
+    { name = "pre-commit", specifier = ">=4.5.1" },
+    { name = "pydantic-settings", specifier = ">=2.1.0" },
+    { name = "pyrefly", specifier = ">=0.2.0" },
+    { name = "ruff", specifier = ">=0.8.0" },
+]
+
+[[package]]
 name = "band-testing-python"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1841,100 +1935,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c8/42/0a540ad5b000192f84e1b135008da22e026cf6ebd392c9e6d41efd6be1a7/thenvoi_client_rest-0.0.4.tar.gz", hash = "sha256:d5d8c3ec46c67375ed077d539c74ccb53c8e3eb446372166a00f8d5a3fd2b6b5", size = 94798, upload-time = "2026-02-15T16:06:50.793Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/a2/e00b4ce8b93d4d1b9a79368935a3c5e61dacd4de63e5e7da5347271b5978/thenvoi_client_rest-0.0.4-py3-none-any.whl", hash = "sha256:64fc2e427f0a347df566741df149a21b677146ef0f59cc268fb9116655ea6cd3", size = 233537, upload-time = "2026-02-15T16:06:48.733Z" },
-]
-
-[[package]]
-name = "thenvoi-mcp"
-version = "1.2.0"
-source = { editable = "." }
-dependencies = [
-    { name = "mcp", extra = ["cli"] },
-    { name = "pydantic-settings" },
-    { name = "thenvoi-client-rest" },
-    { name = "uvicorn" },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "band-testing-python" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "pytest-mock" },
-    { name = "python-dotenv" },
-    { name = "respx" },
-]
-examples = [
-    { name = "langchain" },
-    { name = "langchain-core" },
-    { name = "langchain-mcp-adapters" },
-    { name = "langchain-openai" },
-    { name = "langgraph" },
-    { name = "python-dotenv" },
-]
-langchain = [
-    { name = "langchain" },
-    { name = "langchain-core" },
-    { name = "langchain-mcp-adapters" },
-    { name = "langchain-openai" },
-    { name = "python-dotenv" },
-]
-langgraph = [
-    { name = "langchain-core" },
-    { name = "langchain-mcp-adapters" },
-    { name = "langchain-openai" },
-    { name = "langgraph" },
-    { name = "python-dotenv" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "commitizen" },
-    { name = "pre-commit" },
-    { name = "pydantic-settings" },
-    { name = "pyrefly" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "band-testing-python", marker = "extra == 'dev'", specifier = ">=0.1.4" },
-    { name = "langchain", marker = "extra == 'examples'", specifier = ">=0.3.0" },
-    { name = "langchain", marker = "extra == 'langchain'", specifier = ">=0.3.0" },
-    { name = "langchain-core", marker = "extra == 'examples'", specifier = ">=1.2.5" },
-    { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=1.2.5" },
-    { name = "langchain-core", marker = "extra == 'langgraph'", specifier = ">=1.2.5" },
-    { name = "langchain-mcp-adapters", marker = "extra == 'examples'", specifier = ">=0.1.0" },
-    { name = "langchain-mcp-adapters", marker = "extra == 'langchain'", specifier = ">=0.1.0" },
-    { name = "langchain-mcp-adapters", marker = "extra == 'langgraph'", specifier = ">=0.1.0" },
-    { name = "langchain-openai", marker = "extra == 'examples'", specifier = ">=0.2.0" },
-    { name = "langchain-openai", marker = "extra == 'langchain'", specifier = ">=0.2.0" },
-    { name = "langchain-openai", marker = "extra == 'langgraph'", specifier = ">=0.2.0" },
-    { name = "langgraph", marker = "extra == 'examples'", specifier = ">=0.2.0" },
-    { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=0.2.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.23.0" },
-    { name = "pydantic-settings", specifier = ">=2.1.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
-    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.12.0" },
-    { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "python-dotenv", marker = "extra == 'examples'", specifier = ">=1.0.0" },
-    { name = "python-dotenv", marker = "extra == 'langchain'", specifier = ">=1.0.0" },
-    { name = "python-dotenv", marker = "extra == 'langgraph'", specifier = ">=1.0.0" },
-    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.20.0" },
-    { name = "thenvoi-client-rest", specifier = ">=0.0.4" },
-    { name = "uvicorn", specifier = ">=0.30.0" },
-]
-provides-extras = ["dev", "langgraph", "langchain", "examples"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "commitizen", specifier = ">=3.13.0" },
-    { name = "pre-commit", specifier = ">=4.5.1" },
-    { name = "pydantic-settings", specifier = ">=2.1.0" },
-    { name = "pyrefly", specifier = ">=0.2.0" },
-    { name = "ruff", specifier = ">=0.8.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Renames the Python distribution to `band-mcp` and adds the canonical `band-mcp` CLI.
- Updates docs, examples, release metadata, config defaults, and help text to Band naming and `app.band.ai`.
- Keeps legacy `thenvoi-mcp`, `THENVOI_*`, and `thnv_*` compatibility paths while making `BAND_*` canonical.

## Verification
- `uv run --directory /home/pp/band/thenvoi-mcp --with pytest --with pytest-asyncio --with pytest-cov pytest tests/unit/test_config.py -q` passed: 59 tests.
- `uv build --directory /home/pp/band/thenvoi-mcp` passed and built `band_mcp-1.3.1` artifacts.
- Pre-commit hooks passed on commit: gitleaks, ruff check, ruff format, pyrefly, commitizen.

## Rename boundaries
- Active distribution cutover is `band-mcp`.
- `thenvoi-mcp` remains as a console-script alias in new `band-mcp` installs; this PR does not dual-publish a new `thenvoi-mcp` distribution.
- `thenvoi_mcp` import path and `thenvoi-client-rest` generated dependency remain for compatibility.