### PR TITLE
feat(config): BAND_BASE_URL / BAND_REST_URL aliases for the base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ WARN  unknown --scope value 'huamn' — did you mean 'human'? ignoring.
 | `THENVOI_MCP_TOOLS` / `BAND_MCP_TOOLS`         | Opt-in tool groups: `contacts`, `memory`          |
 | `THENVOI_MCP_ROOM_ID` / `BAND_MCP_ROOM_ID`     | Pinned room id (optional)                         |
 | `THENVOI_API_KEY`                              | Legacy single-key path — **still supported**      |
-| `THENVOI_BASE_URL`                             | API base URL (default: `https://app.thenvoi.com`) |
+| `THENVOI_BASE_URL` / `BAND_BASE_URL` / `BAND_REST_URL` | API base URL (default: `https://app.thenvoi.com`); `THENVOI_BASE_URL` wins when several are set |
 | `TRANSPORT`                                    | `stdio` (default) or `sse`                        |
 | `HOST` / `PORT`                                | SSE bind host/port                                |
 

--- a/src/thenvoi_mcp/config.py
+++ b/src/thenvoi_mcp/config.py
@@ -24,6 +24,7 @@ import difflib
 from dataclasses import dataclass, field
 from typing import Literal, Mapping, Sequence, cast
 
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 Scope = Literal["agent", "human"]
@@ -102,7 +103,14 @@ class Settings(BaseSettings):
 
     # API configuration
     thenvoi_api_key: str = ""
-    thenvoi_base_url: str = "https://app.thenvoi.com"
+    # BAND_* aliases cover the Band rebrand; THENVOI_BASE_URL keeps
+    # precedence (first match wins) for existing deployments.
+    thenvoi_base_url: str = Field(
+        default="https://app.thenvoi.com",
+        validation_alias=AliasChoices(
+            "THENVOI_BASE_URL", "BAND_BASE_URL", "BAND_REST_URL"
+        ),
+    )
 
     # Transport configuration
     transport: Literal["stdio", "sse"] = "stdio"

--- a/src/thenvoi_mcp/server.py
+++ b/src/thenvoi_mcp/server.py
@@ -163,7 +163,8 @@ Environment Variables:
   THENVOI_MCP_TOOLS / BAND_MCP_TOOLS    Opt-in tool groups: contacts, memory
   THENVOI_MCP_ROOM_ID / BAND_MCP_ROOM_ID  Optional pinned room id
   THENVOI_API_KEY       Legacy single-key path (still supported as fallback)
-  THENVOI_BASE_URL      Base URL for Thenvoi API (default: https://app.thenvoi.com)
+  THENVOI_BASE_URL / BAND_BASE_URL / BAND_REST_URL
+                        API base URL (default: https://app.thenvoi.com)
   TRANSPORT             Transport mode: stdio or sse (default: stdio)
   HOST                  Host to bind for SSE mode (default: 127.0.0.1)
   PORT                  Port to bind for SSE mode (default: 8000)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -489,3 +489,25 @@ def test_legacy_ignored_warning_value_field():
     warn = next(w for w in cfg.warnings if w.kind == "legacy-key-ignored")
     assert warn.value == "legacy_key"
     assert warn.did_you_mean is None
+
+
+# ---------------------------------------------------------------------------
+# Base URL env aliases (Band rebrand)
+# ---------------------------------------------------------------------------
+
+
+def test_base_url_band_aliases(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BAND_BASE_URL / BAND_REST_URL are read; THENVOI_BASE_URL keeps precedence."""
+    from thenvoi_mcp.config import Settings
+
+    for var in ("THENVOI_BASE_URL", "BAND_BASE_URL", "BAND_REST_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+    monkeypatch.setenv("BAND_BASE_URL", "https://band-base.example")
+    assert Settings().thenvoi_base_url == "https://band-base.example"
+
+    monkeypatch.setenv("BAND_REST_URL", "https://band-rest.example")
+    assert Settings().thenvoi_base_url == "https://band-base.example"  # BASE wins
+
+    monkeypatch.setenv("THENVOI_BASE_URL", "https://thenvoi.example")
+    assert Settings().thenvoi_base_url == "https://thenvoi.example"  # legacy wins

--- a/uv.lock
+++ b/uv.lock
@@ -1845,7 +1845,7 @@ wheels = [
 
 [[package]]
 name = "thenvoi-mcp"
-version = "1.2.0"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary

The Band rebrand left the API base URL as the one setting without a `BAND_*` env name — the user/agent keys already have aliases (`BAND_USER_KEY`, `BAND_AGENT_KEY`). This adds `BAND_BASE_URL` and `BAND_REST_URL` (the Band SDK's name for the same URL) as aliases via pydantic `AliasChoices`; `THENVOI_BASE_URL` keeps precedence when several are set, so existing deployments are unaffected.

Motivation: band-sdk-python's `examples/letta/docker-compose.yml` had set `BAND_REST_URL` on the band-mcp container, which was silently ignored — this alias makes the Band-named env work everywhere.

## Testing

- [x] `tests/unit/test_config.py` — new `test_base_url_band_aliases` covers both aliases and the precedence order; full config unit suite passes (59 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)