### PR TITLE
fix: stop create_agent_chat_message inducing duplicate mentions

### DIFF
--- a/src/thenvoi_mcp/tools/agent/agent_messages.py
+++ b/src/thenvoi_mcp/tools/agent/agent_messages.py
@@ -160,8 +160,13 @@ def create_agent_chat_message(
 ) -> str:
     """Send a text message in a chat room.
 
-    Creates a new text message in a chat room. Messages MUST include at least
-    one @mention to ensure proper routing to recipients.
+    Creates a new text message in a chat room. To route the message you MUST tag
+    at least one recipient using the `recipients` parameter (names) or the
+    `mentions` parameter (IDs) below.
+
+    IMPORTANT: do NOT write an @mention or @handle inside `content` itself.
+    `content` is plain prose only; the mention is added from `recipients`/
+    `mentions`. Writing an @handle in `content` produces a duplicate mention.
 
     TWO WAYS TO SPECIFY RECIPIENTS:
 
@@ -180,7 +185,9 @@ def create_agent_chat_message(
 
     Args:
         chat_id: The unique identifier of the chat room (required).
-        content: The message content/text (required).
+        content: The message content/text (required). Plain prose only — do NOT
+                 include any @mention or @handle here; tag recipients via
+                 `recipients`/`mentions` instead.
         recipients: Comma-separated participant names to tag (LLM-friendly).
                    Example: "weather agent,sarah,mike"
                    Names are resolved to IDs via list_agent_chat_participants.


### PR DESCRIPTION
## Problem
Agents replying via `create_agent_chat_message` mention the recipient **twice** (two identical chips). Seen live with GitHub Copilot over ACP: a reply stored as `@[[uuid]] @alexander.zaikman Today is …` renders as two `@Alexander Zaikman` chips.

## Root cause
The tool docstring said *"Messages MUST include at least one @mention to ensure proper routing to recipients."* LLM callers satisfied that by writing an `@handle` **into `content`** *and also* passing `recipients`/`mentions`. The `recipients`/`mentions` path already produces the platform's structured mention (the `@[[uuid]]` token/chip), so the literal `@handle` left in `content` renders as a **second** chip.

Neither this tool nor the SDK prepends a handle — `content` is passed verbatim (`agent_messages.py`). The duplication is entirely driven by the model doing both, which the docstring wording invited. The ambiguous wording dates to the 2025-12-13 agent-centric refactor (`ce47cf06`); the prior tool explicitly said *"Include @username in content."*

## Fix
Docstring-only change (top-level + the `content` arg description): the mention comes from `recipients`/`mentions`; `content` is plain prose with no `@handle`. No behavior change.

## Validation
A/B tested live against Copilot over ACP (same model, same prompt): with the old wording the reply had two chips; with this wording the reply is `@[[uuid]] Today is …` — a single chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)